### PR TITLE
LAS Version 1.2 Support

### DIFF
--- a/WellLog.Lib.Test/Business/AsciiLogDataBusinessTests.cs
+++ b/WellLog.Lib.Test/Business/AsciiLogDataBusinessTests.cs
@@ -1,0 +1,78 @@
+﻿using NUnit.Framework;
+using System.Linq;
+using WellLog.Lib.Business;
+using WellLog.Lib.Enumerations;
+using WellLog.Lib.Exceptions;
+using WellLog.Lib.Models;
+
+namespace WellLog.Lib.Test.Business
+{
+    [TestFixture]
+    public class AsciiLogDataBusinessTests
+    {
+        private AsciiLogDataBusiness _asciiLogDataBusiness;
+
+        [SetUp]
+        public void PerTestSetup()
+        {
+            _asciiLogDataBusiness = new AsciiLogDataBusiness();
+        }
+
+        [Test]
+        public void AsciiLogDataBusiness_UnWrapAsciiLogData_Pass_NullSection()
+        {
+            Assert.DoesNotThrow(() => _asciiLogDataBusiness.UnWrapAsciiLogData(null));
+        }
+
+        [Test]
+        public void AsciiLogDataBusiness_UnWrapAsciiLogData_Pass_NullAsciiLogData()
+        {
+            Assert.DoesNotThrow(() => _asciiLogDataBusiness.UnWrapAsciiLogData(new LasSection()));
+        }
+
+        [Test]
+        public void AsciiLogDataBusiness_UnWrapAsciiLogData_Pass_EmptyAsciiLogData()
+        {
+            Assert.DoesNotThrow(() => _asciiLogDataBusiness.UnWrapAsciiLogData(new LasSection { AsciiLogDataLines = new LasAsciiLogDataLine[0] }));
+        }
+
+        [Test]
+        public void AsciiLogDataBusiness_UnWrapAsciiLogData_Fail_InvalidLineWrapping()
+        {
+            var asciiLogData = new LasSection
+            {
+                SectionType = LasSectionType.AsciiLogData,
+                AsciiLogDataLines = new LasAsciiLogDataLine[]
+                {
+                    new LasAsciiLogDataLine{ Values = new string[] { "-999.25", "-999.25", "-999.25" } },
+                    new LasAsciiLogDataLine{ Values = new string[] { "-999.25", "-999.25", "-999.25" } },
+                    new LasAsciiLogDataLine{ Values = new string[] { "-999.25", "-999.25", "-999.25" } }
+                }
+            };
+
+            Assert.Throws<LasLogFormatException>(() => _asciiLogDataBusiness.UnWrapAsciiLogData(asciiLogData));
+        }
+
+        [Test]
+        public void AsciiLogDataBusiness_UnWrapAsciiLogData_Pass()
+        {
+            var asciiLogData = new LasSection
+            {
+                SectionType = LasSectionType.AsciiLogData,
+                AsciiLogDataLines = new LasAsciiLogDataLine[]
+                {
+                    new LasAsciiLogDataLine{ Values = new string[] { "-999.25" } },
+                    new LasAsciiLogDataLine{ Values = new string[] { "-999.25", "-999.25", "-999.25" } },
+                    new LasAsciiLogDataLine{ Values = new string[] { "-999.25", "-999.25", "-999.25" } },
+                    new LasAsciiLogDataLine{ Values = new string[] { "-999.25" } },
+                    new LasAsciiLogDataLine{ Values = new string[] { "-999.25", "-999.25", "-999.25" } },
+                    new LasAsciiLogDataLine{ Values = new string[] { "-999.25", "-999.25", "-999.25" } }
+                }
+            };
+
+            _asciiLogDataBusiness.UnWrapAsciiLogData(asciiLogData);
+
+            Assert.AreEqual(2, asciiLogData.AsciiLogDataLines.Count());
+        }
+    }
+}

--- a/WellLog.Lib.Test/Business/LasLogBusinessTests.cs
+++ b/WellLog.Lib.Test/Business/LasLogBusinessTests.cs
@@ -10,13 +10,18 @@ namespace WellLog.Lib.Test.Business
     public class LasLogBusinessTests
     {
         private Mock<ILasSectionBusiness> _lasSectionBusiness;
+        private Mock<IAsciiLogDataBusiness> _asciiLogDataBusiness;
+        private Mock<IWellInformationBusiness> _wellInformationBusiness;
         private LasLogBusiness _lasLogBusiness;
 
         [SetUp]
         public void PerTestSetup()
         {
             _lasSectionBusiness = new Mock<ILasSectionBusiness>();
-            _lasLogBusiness = new LasLogBusiness(_lasSectionBusiness.Object);
+            _asciiLogDataBusiness = new Mock<IAsciiLogDataBusiness>();
+            _wellInformationBusiness = new Mock<IWellInformationBusiness>();
+
+            _lasLogBusiness = new LasLogBusiness(_lasSectionBusiness.Object, _asciiLogDataBusiness.Object, _wellInformationBusiness.Object);
         }
 
         [Test]

--- a/WellLog.Lib.Test/Business/WellInformationDataBusinessTests.cs
+++ b/WellLog.Lib.Test/Business/WellInformationDataBusinessTests.cs
@@ -1,0 +1,92 @@
+﻿using NUnit.Framework;
+using System.Linq;
+using WellLog.Lib.Business;
+using WellLog.Lib.Enumerations;
+using WellLog.Lib.Exceptions;
+using WellLog.Lib.Models;
+using WellLog.Lib.Helpers;
+
+namespace WellLog.Lib.Test.Business
+{
+    [TestFixture]
+    public class WellInformationDataBusinessTests
+    {
+        private WellInformationBusiness _wellInformationBusiness;
+
+        [SetUp]
+        public void PerTestSetup()
+        {
+            _wellInformationBusiness = new WellInformationBusiness();
+        }
+
+        [Test]
+        public void WellInformationBusiness_FixWellInformation_Pass_NullSection()
+        {
+            Assert.DoesNotThrow(() => _wellInformationBusiness.FixWellInformation(null));
+        }
+
+        [Test]
+        public void WellInformationBusiness_FixWellInformation_Pass_NullMnemonicLines()
+        {
+            Assert.DoesNotThrow(() => _wellInformationBusiness.FixWellInformation(new LasSection()));
+        }
+
+        [Test]
+        public void WellInformationBusiness_UnWrapAsciiLogData_Pass_EmptyMnemonicLines()
+        {
+            Assert.DoesNotThrow(() => _wellInformationBusiness.FixWellInformation(new LasSection { MnemonicsLines = new LasMnemonicLine[0] }));
+        }
+
+        [Test]
+        public void WellInformationBusiness_FixWellInformation_Pass()
+        {
+            var company = "ANY OIL COMPANY INC.";
+            var well = "SOME WELL NAME";
+            var field = "THAT FIELD OVER THERE";
+            var location = "THIS LOCATION";
+            var province = "ONTARIO";
+            var county = "CREEK";
+            var state = "OKLAHOMA";
+            var country = "USA";
+            var serviceCompany = "ONTARIO";
+            var dateLogged = "CREEK";
+            var uwi = "OKLAHOMA";
+            var api = "USA";
+
+            var wellInformationSection = new LasSection
+            {
+                SectionType = LasSectionType.WellInformation,
+                MnemonicsLines = new LasMnemonicLine[]
+                {
+                    new LasMnemonicLine{ Mnemonic = "COMP", Units = "", Data = "COMPANY", Description = company },
+                    new LasMnemonicLine{ Mnemonic = "WELL", Units = "", Data = "WELL NAME", Description = well },
+                    new LasMnemonicLine{ Mnemonic = "FLD", Units = "", Data = "FIELD NAME", Description = field },
+                    new LasMnemonicLine{ Mnemonic = "LOC", Units = "", Data = "LOCATION", Description = location },
+                    new LasMnemonicLine{ Mnemonic = "PROV", Units = "", Data = "PROVINCE", Description = province },
+                    new LasMnemonicLine{ Mnemonic = "CNTY", Units = "", Data = "COUNTY", Description = county },
+                    new LasMnemonicLine{ Mnemonic = "STAT", Units = "", Data = "STATE", Description = state },
+                    new LasMnemonicLine{ Mnemonic = "CTRY", Units = "", Data = "COUNTRY", Description = country },
+                    new LasMnemonicLine{ Mnemonic = "SRVC", Units = "", Data = "SERVICE COMPANY", Description = serviceCompany },
+                    new LasMnemonicLine{ Mnemonic = "DATE", Units = "", Data = "DATE LOGGED", Description = dateLogged },
+                    new LasMnemonicLine{ Mnemonic = "UWI", Units = "", Data = "UNIQUE WELL ID", Description = uwi },
+                    new LasMnemonicLine{ Mnemonic = "API", Units = "", Data = "API NUMBER", Description = api }
+                }
+            };
+
+            _wellInformationBusiness.FixWellInformation(wellInformationSection);
+
+            Assert.AreEqual(company, wellInformationSection.GetCompanyMnemonic().Data);
+            Assert.AreEqual(well, wellInformationSection.GetWellMnemonic().Data);
+            Assert.AreEqual(field, wellInformationSection.GetFieldMnemonic().Data);
+            Assert.AreEqual(location, wellInformationSection.GetLocationMnemonic().Data);
+            Assert.AreEqual(province, wellInformationSection.GetProvinceMnemonic().Data);
+            Assert.AreEqual(county, wellInformationSection.GetCountyMnemonic().Data);
+            Assert.AreEqual(state, wellInformationSection.GetStateMnemonic().Data);
+            Assert.AreEqual(country, wellInformationSection.GetCountryMnemonic().Data);
+            Assert.AreEqual(serviceCompany, wellInformationSection.GetServiceCompanyMnemonic().Data);
+            Assert.AreEqual(dateLogged, wellInformationSection.GetDateMnemonic().Data);
+            Assert.AreEqual(uwi, wellInformationSection.GetUwiMnemonic().Data);
+            Assert.AreEqual(api, wellInformationSection.GetApiMnemonic().Data);
+        }
+    }
+}

--- a/WellLog.Lib.Test/Helpers/LasLogHelpersTests.cs
+++ b/WellLog.Lib.Test/Helpers/LasLogHelpersTests.cs
@@ -50,17 +50,6 @@ namespace WellLog.Lib.Test.Helpers
             }
         };
 
-        private static readonly LasSection threeChannelCurveSection = new LasSection
-        {
-            SectionType = LasSectionType.CurveInformation,
-            MnemonicsLines = new LasMnemonicLine[]
-            {
-                new LasMnemonicLine { Mnemonic = "DEPTH", Units = "FEET" },
-                new LasMnemonicLine { Mnemonic = "GR", Units = "RAD" },
-                new LasMnemonicLine { Mnemonic = "TEMP", Units = "DEGF" }
-            }
-        };
-
         private static readonly LasSection oneChannelAsciiLogData = new LasSection
         {
             SectionType = LasSectionType.AsciiLogData,
@@ -168,35 +157,33 @@ namespace WellLog.Lib.Test.Helpers
         [Test]
         public void LasLogHelpers_FileVersion_Pass_Null()
         {
-            LasLog lasLog = null;
-            Assert.AreEqual(LasFileVersion.LAS_2_0, lasLog.FileVersion());
+            Assert.AreEqual(LasFileVersion.LAS_2_0, nullLog.FileVersion());
         }
 
         [Test]
         public void LasLogHelpers_FileVersion_Pass_NoSections()
         {
-            LasLog lasLog = new LasLog();
-            Assert.AreEqual(LasFileVersion.LAS_2_0, lasLog.FileVersion());
+            Assert.AreEqual(LasFileVersion.LAS_2_0, noSections.FileVersion());
         }
 
         [Test]
         public void LasLogHelpers_FileVersion_Pass_NoVersionInfo()
         {
-            LasLog lasLog = new LasLog { Sections = new LasSection[] { new LasSection() } };
+            var lasLog = new LasLog { Sections = new LasSection[] { new LasSection() } };
             Assert.AreEqual(LasFileVersion.LAS_2_0, lasLog.FileVersion());
         }
 
         [Test]
         public void LasLogHelpers_FileVersion_Pass_NoVersionMnemonic()
         {
-            LasLog lasLog = new LasLog { Sections = new LasSection[] { new LasSection { SectionType = LasSectionType.VersionInformation } } };
+            var lasLog = new LasLog { Sections = new LasSection[] { new LasSection { SectionType = LasSectionType.VersionInformation } } };
             Assert.AreEqual(LasFileVersion.LAS_2_0, lasLog.FileVersion());
         }
 
         [Test]
         public void LasLogHelpers_FileVersion_Pass_Version12()
         {
-            LasLog lasLog = new LasLog
+            var lasLog = new LasLog
             {
                 Sections = new LasSection[]
                 {
@@ -216,7 +203,7 @@ namespace WellLog.Lib.Test.Helpers
         [Test]
         public void LasLogHelpers_FileVersion_Pass_Version20()
         {
-            LasLog lasLog = new LasLog
+            var lasLog = new LasLog
             {
                 Sections = new LasSection[]
                 {

--- a/WellLog.Lib.Test/Helpers/LasLogHelpersTests.cs
+++ b/WellLog.Lib.Test/Helpers/LasLogHelpersTests.cs
@@ -164,5 +164,73 @@ namespace WellLog.Lib.Test.Helpers
             Assert.AreEqual(WELL_ID, withUwiWellId.WellIdentifier());
             Assert.AreEqual(WELL_ID, withApiWellId.WellIdentifier());
         }
+
+        [Test]
+        public void LasLogHelpers_FileVersion_Pass_Null()
+        {
+            LasLog lasLog = null;
+            Assert.AreEqual(LasFileVersion.LAS_2_0, lasLog.FileVersion());
+        }
+
+        [Test]
+        public void LasLogHelpers_FileVersion_Pass_NoSections()
+        {
+            LasLog lasLog = new LasLog();
+            Assert.AreEqual(LasFileVersion.LAS_2_0, lasLog.FileVersion());
+        }
+
+        [Test]
+        public void LasLogHelpers_FileVersion_Pass_NoVersionInfo()
+        {
+            LasLog lasLog = new LasLog { Sections = new LasSection[] { new LasSection() } };
+            Assert.AreEqual(LasFileVersion.LAS_2_0, lasLog.FileVersion());
+        }
+
+        [Test]
+        public void LasLogHelpers_FileVersion_Pass_NoVersionMnemonic()
+        {
+            LasLog lasLog = new LasLog { Sections = new LasSection[] { new LasSection { SectionType = LasSectionType.VersionInformation } } };
+            Assert.AreEqual(LasFileVersion.LAS_2_0, lasLog.FileVersion());
+        }
+
+        [Test]
+        public void LasLogHelpers_FileVersion_Pass_Version12()
+        {
+            LasLog lasLog = new LasLog
+            {
+                Sections = new LasSection[]
+                {
+                    new LasSection
+                    {
+                        SectionType = LasSectionType.VersionInformation,
+                        MnemonicsLines = new LasMnemonicLine[]
+                        {
+                            new LasMnemonicLine{ Mnemonic = "VERS", Data = "1.2" }
+                        }
+                    }
+                }
+            };
+            Assert.AreEqual(LasFileVersion.LAS_1_2, lasLog.FileVersion());
+        }
+
+        [Test]
+        public void LasLogHelpers_FileVersion_Pass_Version20()
+        {
+            LasLog lasLog = new LasLog
+            {
+                Sections = new LasSection[]
+                {
+                    new LasSection
+                    {
+                        SectionType = LasSectionType.VersionInformation,
+                        MnemonicsLines = new LasMnemonicLine[]
+                        {
+                            new LasMnemonicLine{ Mnemonic = "VERS", Data = "2.0" }
+                        }
+                    }
+                }
+            };
+            Assert.AreEqual(LasFileVersion.LAS_2_0, lasLog.FileVersion());
+        }
     }
 }

--- a/WellLog.Lib.Test/Helpers/LasMnemonicLineHelpersTests.cs
+++ b/WellLog.Lib.Test/Helpers/LasMnemonicLineHelpersTests.cs
@@ -8,7 +8,7 @@ namespace WellLog.Lib.Test.Helpers
     public class LasMnemonicLineHelpersTests
     {
         private static readonly LasMnemonicLine nullMnemonicLine = null;
-        private static readonly LasMnemonicLine mnemonicLine = new LasMnemonicLine { Mnemonic = "MNEM" };
+        private static readonly LasMnemonicLine mnemonicLine = new LasMnemonicLine { Mnemonic = "MNEM", Data = "DATA", Description = "DESCRIPTION" };
 
         [Test]
         public void LasMnemonicLineHelpers_IsMnemonic_Pass()
@@ -17,6 +17,19 @@ namespace WellLog.Lib.Test.Helpers
             Assert.IsTrue(mnemonicLine.IsMnemonic("MNEM"));
             Assert.IsTrue(mnemonicLine.IsMnemonic("A", "B", "MNEM"));
             Assert.IsFalse(mnemonicLine.IsMnemonic("A"));
+        }
+
+        [Test]
+        public void LasMnemonicLineHelpers_SwapDataDescription_Pass()
+        {
+            var data = "DATA";
+            var description = "DESCRIPTION";
+            var dataMnemonicLine = new LasMnemonicLine { Data = data, Description = description };
+            dataMnemonicLine.SwapDataDescription();
+
+            Assert.DoesNotThrow(() => nullMnemonicLine.SwapDataDescription());
+            Assert.AreEqual(data, dataMnemonicLine.Description);
+            Assert.AreEqual(description, dataMnemonicLine.Data);
         }
     }
 }

--- a/WellLog.Lib.Test/Helpers/LasVersionInformationHelpersTests.cs
+++ b/WellLog.Lib.Test/Helpers/LasVersionInformationHelpersTests.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using WellLog.Lib.Enumerations;
 using WellLog.Lib.Helpers;
 using WellLog.Lib.Models;
 
@@ -8,14 +7,17 @@ namespace WellLog.Lib.Test.Helpers
     [TestFixture]
     public class LasVersionInformationHelpersTests
     {
+        private static readonly LasMnemonicLine versionMnemonicLine = new LasMnemonicLine { Mnemonic = "VERS", Data = "2.0", Description = "LAS FILE VERSION" };
+        private static readonly LasMnemonicLine wrapMnemonicLine = new LasMnemonicLine { Mnemonic = "WRAP", Data = "NO", Description = "USES LINE WRAP" };
+
         private static readonly LasSection nullSection = null;
         private static readonly LasSection emptySection = new LasSection();
         private static readonly LasSection versionInformationSection = new LasSection
         {
             MnemonicsLines = new LasMnemonicLine[]
             {
-                new LasMnemonicLine { Mnemonic = "VERS" },
-                new LasMnemonicLine { Mnemonic = "WRAP" }
+                versionMnemonicLine,
+                wrapMnemonicLine
             }
         };
 
@@ -33,6 +35,14 @@ namespace WellLog.Lib.Test.Helpers
             Assert.IsFalse(nullSection.HasWrapMnemonic());
             Assert.IsFalse(emptySection.HasWrapMnemonic());
             Assert.IsTrue(versionInformationSection.HasWrapMnemonic());
+        }
+
+        [Test]
+        public void LasVersionInformationHelpers_GetVersionMnemonic_Pass()
+        {
+            Assert.IsNull(nullSection.GetVersionMnemonic());
+            Assert.IsNull(emptySection.GetVersionMnemonic());
+            Assert.AreSame(versionMnemonicLine, versionInformationSection.GetVersionMnemonic());
         }
     }
 }

--- a/WellLog.Lib.Test/Helpers/LasWellInformationHelpersTests.cs
+++ b/WellLog.Lib.Test/Helpers/LasWellInformationHelpersTests.cs
@@ -7,8 +7,22 @@ namespace WellLog.Lib.Test.Helpers
     [TestFixture]
     public class LasWellInformationHelpersTests
     {
-        private static readonly LasMnemonicLine uwiLine = new LasMnemonicLine { Mnemonic = "UWI" };
-        private static readonly LasMnemonicLine apiLine = new LasMnemonicLine { Mnemonic = "API" };
+        private static readonly LasMnemonicLine startMnemonicLine = new LasMnemonicLine { Mnemonic = "STRT", Units = "FEET", Data = "100.0", Description = "START DEPTH" };
+        private static readonly LasMnemonicLine stopMnemonicLine = new LasMnemonicLine { Mnemonic = "STOP", Units = "FEET", Data = "101.0", Description = "STOP DEPTH" };
+        private static readonly LasMnemonicLine stepMnemonicLine = new LasMnemonicLine { Mnemonic = "STEP", Units = "FEET", Data = "0.5", Description = "DEPTH STEP" };
+        private static readonly LasMnemonicLine nullMnemonicLine = new LasMnemonicLine { Mnemonic = "NULL", Data = "-999.25", Description = "NULL VALUE" };
+        private static readonly LasMnemonicLine companyMnemonicLine = new LasMnemonicLine { Mnemonic = "COMP", Data = "ANY COMPANY", Description = "COMPANY" };
+        private static readonly LasMnemonicLine wellMnemonicLine = new LasMnemonicLine { Mnemonic = "WELL", Data = "ANY WELL", Description = "WELL NAME" };
+        private static readonly LasMnemonicLine fieldMnemonicLine = new LasMnemonicLine { Mnemonic = "FLD", Data = "ANY FIELD", Description = "FIELD NAME" };
+        private static readonly LasMnemonicLine locationMnemonicLine = new LasMnemonicLine { Mnemonic = "LOC", Data = "ANY LOCATION", Description = "LOCATION" };
+        private static readonly LasMnemonicLine provinceMnemonicLine = new LasMnemonicLine { Mnemonic = "PROV", Data = "ANY PROVINCE", Description = "PROVINCE" };
+        private static readonly LasMnemonicLine countyMnemonicLine = new LasMnemonicLine { Mnemonic = "CNTY", Data = "ANY COUNTY", Description = "COUNTY" };
+        private static readonly LasMnemonicLine stateMnemonicLine = new LasMnemonicLine { Mnemonic = "STAT", Data = "ANY STATE", Description = "STATE" };
+        private static readonly LasMnemonicLine countryMnemonicLine = new LasMnemonicLine { Mnemonic = "CTRY", Data = "ANY COUNTRY", Description = "COUNTRY" };
+        private static readonly LasMnemonicLine serviceCompanyMnemonicLine = new LasMnemonicLine { Mnemonic = "SRVC", Data = "ANY SERVICE COMPANY", Description = "SERVICE COMPANY" };
+        private static readonly LasMnemonicLine dateMnemonicLine = new LasMnemonicLine { Mnemonic = "DATE", Data = "2020-03-25", Description = "DATE LOGGED" };
+        private static readonly LasMnemonicLine uwiMnemonicLine = new LasMnemonicLine { Mnemonic = "UWI", Data = "123456789012", Description = "UNIQUE WELL ID" };
+        private static readonly LasMnemonicLine apiMnemonicLine = new LasMnemonicLine { Mnemonic = "API", Data = "123456789012", Description = "API NUMBER" };
 
         private static readonly LasSection nullSection = null;
         private static readonly LasSection emptySection = new LasSection();
@@ -16,22 +30,22 @@ namespace WellLog.Lib.Test.Helpers
         {
             MnemonicsLines = new LasMnemonicLine[]
             {
-                new LasMnemonicLine { Mnemonic = "STRT" },
-                new LasMnemonicLine { Mnemonic = "STOP" },
-                new LasMnemonicLine { Mnemonic = "STEP" },
-                new LasMnemonicLine { Mnemonic = "NULL" },
-                new LasMnemonicLine { Mnemonic = "COMP" },
-                new LasMnemonicLine { Mnemonic = "WELL" },
-                new LasMnemonicLine { Mnemonic = "FLD" },
-                new LasMnemonicLine { Mnemonic = "LOC" },
-                new LasMnemonicLine { Mnemonic = "PROV" },
-                new LasMnemonicLine { Mnemonic = "CNTY" },
-                new LasMnemonicLine { Mnemonic = "STAT" },
-                new LasMnemonicLine { Mnemonic = "CTRY" },
-                new LasMnemonicLine { Mnemonic = "SRVC" },
-                new LasMnemonicLine { Mnemonic = "DATE" },
-                uwiLine,
-                apiLine
+                startMnemonicLine,
+                stopMnemonicLine,
+                stepMnemonicLine,
+                nullMnemonicLine,
+                companyMnemonicLine,
+                wellMnemonicLine,
+                fieldMnemonicLine,
+                locationMnemonicLine,
+                provinceMnemonicLine,
+                countyMnemonicLine,
+                stateMnemonicLine,
+                countryMnemonicLine,
+                serviceCompanyMnemonicLine,
+                dateMnemonicLine,
+                uwiMnemonicLine,
+                apiMnemonicLine
             }
         };
 
@@ -180,11 +194,91 @@ namespace WellLog.Lib.Test.Helpers
         }
 
         [Test]
+        public void LasWellInformationHelpers_GetCompanyMnemonic_Pass()
+        {
+            Assert.IsNull(nullSection.GetCompanyMnemonic());
+            Assert.IsNull(emptySection.GetCompanyMnemonic());
+            Assert.AreSame(companyMnemonicLine, wellInformationSection.GetCompanyMnemonic());
+        }
+
+        [Test]
+        public void LasWellInformationHelpers_GetWellMnemonic_Pass()
+        {
+            Assert.IsNull(nullSection.GetWellMnemonic());
+            Assert.IsNull(emptySection.GetWellMnemonic());
+            Assert.AreSame(wellMnemonicLine, wellInformationSection.GetWellMnemonic());
+        }
+
+        [Test]
+        public void LasWellInformationHelpers_GetFieldMnemonic_Pass()
+        {
+            Assert.IsNull(nullSection.GetFieldMnemonic());
+            Assert.IsNull(emptySection.GetFieldMnemonic());
+            Assert.AreSame(fieldMnemonicLine, wellInformationSection.GetFieldMnemonic());
+        }
+
+        [Test]
+        public void LasWellInformationHelpers_GetLocationMnemonic_Pass()
+        {
+            Assert.IsNull(nullSection.GetLocationMnemonic());
+            Assert.IsNull(emptySection.GetLocationMnemonic());
+            Assert.AreSame(locationMnemonicLine, wellInformationSection.GetLocationMnemonic());
+        }
+
+        [Test]
+        public void LasWellInformationHelpers_GetProvinceMnemonic_Pass()
+        {
+            Assert.IsNull(nullSection.GetProvinceMnemonic());
+            Assert.IsNull(emptySection.GetProvinceMnemonic());
+            Assert.AreSame(provinceMnemonicLine, wellInformationSection.GetProvinceMnemonic());
+        }
+
+        [Test]
+        public void LasWellInformationHelpers_GetCountyMnemonic_Pass()
+        {
+            Assert.IsNull(nullSection.GetCountyMnemonic());
+            Assert.IsNull(emptySection.GetCountyMnemonic());
+            Assert.AreSame(countyMnemonicLine, wellInformationSection.GetCountyMnemonic());
+        }
+
+        [Test]
+        public void LasWellInformationHelpers_GetStateMnemonic_Pass()
+        {
+            Assert.IsNull(nullSection.GetStateMnemonic());
+            Assert.IsNull(emptySection.GetStateMnemonic());
+            Assert.AreSame(stateMnemonicLine, wellInformationSection.GetStateMnemonic());
+        }
+
+        [Test]
+        public void LasWellInformationHelpers_GetCountryMnemonic_Pass()
+        {
+            Assert.IsNull(nullSection.GetCountryMnemonic());
+            Assert.IsNull(emptySection.GetCountryMnemonic());
+            Assert.AreSame(countryMnemonicLine, wellInformationSection.GetCountryMnemonic());
+        }
+
+        [Test]
+        public void LasWellInformationHelpers_GetServiceCompanyMnemonic_Pass()
+        {
+            Assert.IsNull(nullSection.GetServiceCompanyMnemonic());
+            Assert.IsNull(emptySection.GetServiceCompanyMnemonic());
+            Assert.AreSame(serviceCompanyMnemonicLine, wellInformationSection.GetServiceCompanyMnemonic());
+        }
+
+        [Test]
+        public void LasWellInformationHelpers_GetDateMnemonic_Pass()
+        {
+            Assert.IsNull(nullSection.GetDateMnemonic());
+            Assert.IsNull(emptySection.GetDateMnemonic());
+            Assert.AreSame(dateMnemonicLine, wellInformationSection.GetDateMnemonic());
+        }
+
+        [Test]
         public void LasWellInformationHelpers_GetUwiMnemonic_Pass()
         {
             Assert.IsNull(nullSection.GetUwiMnemonic());
             Assert.IsNull(emptySection.GetUwiMnemonic());
-            Assert.AreSame(uwiLine, wellInformationSection.GetUwiMnemonic());
+            Assert.AreSame(uwiMnemonicLine, wellInformationSection.GetUwiMnemonic());
         }
 
         [Test]
@@ -192,7 +286,7 @@ namespace WellLog.Lib.Test.Helpers
         {
             Assert.IsNull(nullSection.GetApiMnemonic());
             Assert.IsNull(emptySection.GetApiMnemonic());
-            Assert.AreSame(apiLine, wellInformationSection.GetApiMnemonic());
+            Assert.AreSame(apiMnemonicLine, wellInformationSection.GetApiMnemonic());
         }
     }
 }

--- a/WellLog.Lib/Business/AsciiLogDataBusiness.cs
+++ b/WellLog.Lib/Business/AsciiLogDataBusiness.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using WellLog.Lib.Exceptions;
+using WellLog.Lib.Models;
+
+namespace WellLog.Lib.Business
+{
+    public class AsciiLogDataBusiness : IAsciiLogDataBusiness
+    {
+        public void UnWrapAsciiLogData(LasSection lasSection)
+        {
+            if (lasSection == null) { return; }
+            if (lasSection.AsciiLogDataLines == null) { return; }
+
+            var asciiLogDataLines = new List<LasAsciiLogDataLine>();
+            List<string> lineValues = null;
+            foreach (var line in lasSection.AsciiLogDataLines)
+            {
+                var valueCount = line.Values.Count();
+                if (valueCount < 1) { continue; }
+                if (valueCount == 1)
+                {
+                    if (lineValues != null) { asciiLogDataLines.Add(new LasAsciiLogDataLine { Values = lineValues.ToArray() }); }
+                    lineValues = new List<string>();
+                }
+
+                if (lineValues == null) { throw new LasLogFormatException("Invalid line wrapping.  In wrap mode, the index channel must be on its own line."); }
+                lineValues.AddRange(line.Values);
+            }
+            if (lineValues != null) { asciiLogDataLines.Add(new LasAsciiLogDataLine { Values = lineValues.ToArray() }); }
+
+            lasSection.AsciiLogDataLines = asciiLogDataLines.ToArray();
+        }
+    }
+}

--- a/WellLog.Lib/Business/IAsciiLogDataBusiness.cs
+++ b/WellLog.Lib/Business/IAsciiLogDataBusiness.cs
@@ -1,0 +1,9 @@
+﻿using WellLog.Lib.Models;
+
+namespace WellLog.Lib.Business
+{
+    public interface IAsciiLogDataBusiness
+    {
+        void UnWrapAsciiLogData(LasSection lasSection);
+    }
+}

--- a/WellLog.Lib/Business/IWellInformationBusiness.cs
+++ b/WellLog.Lib/Business/IWellInformationBusiness.cs
@@ -1,0 +1,9 @@
+﻿using WellLog.Lib.Models;
+
+namespace WellLog.Lib.Business
+{
+    public interface IWellInformationBusiness
+    {
+        void FixWellInformation(LasSection lasSection);
+    }
+}

--- a/WellLog.Lib/Business/WellInformationBusiness.cs
+++ b/WellLog.Lib/Business/WellInformationBusiness.cs
@@ -1,0 +1,24 @@
+﻿using WellLog.Lib.Helpers;
+using WellLog.Lib.Models;
+
+namespace WellLog.Lib.Business
+{
+    public class WellInformationBusiness : IWellInformationBusiness
+    {
+        public void FixWellInformation(LasSection lasSection)
+        {
+            lasSection.GetCompanyMnemonic().SwapDataDescription();
+            lasSection.GetWellMnemonic().SwapDataDescription();
+            lasSection.GetFieldMnemonic().SwapDataDescription();
+            lasSection.GetLocationMnemonic().SwapDataDescription();
+            lasSection.GetProvinceMnemonic().SwapDataDescription();
+            lasSection.GetCountyMnemonic().SwapDataDescription();
+            lasSection.GetStateMnemonic().SwapDataDescription();
+            lasSection.GetCountryMnemonic().SwapDataDescription();
+            lasSection.GetServiceCompanyMnemonic().SwapDataDescription();
+            lasSection.GetDateMnemonic().SwapDataDescription();
+            lasSection.GetUwiMnemonic().SwapDataDescription();
+            lasSection.GetApiMnemonic().SwapDataDescription();
+        }
+    }
+}

--- a/WellLog.Lib/Enumerations/LasFileVersion.cs
+++ b/WellLog.Lib/Enumerations/LasFileVersion.cs
@@ -1,0 +1,8 @@
+﻿namespace WellLog.Lib.Enumerations
+{
+    public enum LasFileVersion
+    {
+        LAS_1_2,
+        LAS_2_0
+    }
+}

--- a/WellLog.Lib/Exceptions/LasLogFormatException.cs
+++ b/WellLog.Lib/Exceptions/LasLogFormatException.cs
@@ -1,5 +1,4 @@
-﻿using WellLog.Lib.Models;
-using System;
+﻿using System;
 using System.Runtime.Serialization;
 using System.Security.Permissions;
 
@@ -8,25 +7,20 @@ namespace WellLog.Lib.Exceptions
     [Serializable]
     public class LasLogFormatException : Exception
     {
-        public LasLog Log { get; private set; }
-
-        public LasLogFormatException(string message, LasLog log)
+        public LasLogFormatException(string message)
             : base(message)
         {
-            if (log != null) { Log = log; }
         }
 
         protected LasLogFormatException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            Log = (LasLog)info.GetValue("Log", typeof(LasLog));
         }
 
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
-            info.AddValue("Log", Log);
         }
     }
 }

--- a/WellLog.Lib/Helpers/LasLogHelpers.cs
+++ b/WellLog.Lib/Helpers/LasLogHelpers.cs
@@ -1,6 +1,6 @@
-﻿using WellLog.Lib.Enumerations;
+﻿using System.Linq;
+using WellLog.Lib.Enumerations;
 using WellLog.Lib.Models;
-using System.Linq;
 
 namespace WellLog.Lib.Helpers
 {
@@ -8,6 +8,7 @@ namespace WellLog.Lib.Helpers
     {
         private const string MNEM_WRAP = "WRAP";
         private const string WRAP_YES = "YES";
+        private const string LAS_VERSION_1_2 = "1.2";
 
         public static bool HasSection(this LasLog lasLog, LasSectionType lasSectionType)
         {
@@ -76,6 +77,17 @@ namespace WellLog.Lib.Helpers
             if (apiMnemonic != null) { return apiMnemonic.Data; }
 
             return string.Empty;
+        }
+
+        public static LasFileVersion FileVersion(this LasLog lasLog)
+        {
+            if (lasLog == null) { return LasFileVersion.LAS_2_0; }
+
+            var versionMnemonic = lasLog.VersionInformation.GetVersionMnemonic();
+            if (versionMnemonic == null) { return LasFileVersion.LAS_2_0; }
+
+            if (string.Compare(versionMnemonic.Data, LAS_VERSION_1_2, true) == 0) { return LasFileVersion.LAS_1_2; }
+            return LasFileVersion.LAS_2_0;
         }
     }
 }

--- a/WellLog.Lib/Helpers/LasMnemonicLineHelpers.cs
+++ b/WellLog.Lib/Helpers/LasMnemonicLineHelpers.cs
@@ -11,5 +11,13 @@ namespace WellLog.Lib.Helpers
             if (mnemonics == null) { return false; }
             return mnemonics.Any(x => string.Compare(x, lasMnemonicLine.Mnemonic, true) == 0);
         }
+
+        public static void SwapDataDescription(this LasMnemonicLine lasMnemonicLine)
+        {
+            if (lasMnemonicLine == null) { return; }
+            var temp = lasMnemonicLine.Data;
+            lasMnemonicLine.Data = lasMnemonicLine.Description;
+            lasMnemonicLine.Description = temp;
+        }
     }
 }

--- a/WellLog.Lib/Helpers/LasVersionInformationHelpers.cs
+++ b/WellLog.Lib/Helpers/LasVersionInformationHelpers.cs
@@ -17,5 +17,10 @@ namespace WellLog.Lib.Helpers
         {
             return lasSection.HasMnemonic(MNEM_WRAP);
         }
+
+        public static LasMnemonicLine GetVersionMnemonic(this LasSection lasSection)
+        {
+            return lasSection.GetMnemonic(MNEM_VERS);
+        }
     }
 }

--- a/WellLog.Lib/Helpers/LasWellInformationHelpers.cs
+++ b/WellLog.Lib/Helpers/LasWellInformationHelpers.cs
@@ -120,5 +120,55 @@ namespace WellLog.Lib.Helpers
         {
             return lasSection.GetMnemonic(MNEM_API);
         }
+
+        public static LasMnemonicLine GetCompanyMnemonic(this LasSection lasSection)
+        {
+            return lasSection.GetMnemonic(MNEM_COMP);
+        }
+
+        public static LasMnemonicLine GetWellMnemonic(this LasSection lasSection)
+        {
+            return lasSection.GetMnemonic(MNEM_WELL);
+        }
+
+        public static LasMnemonicLine GetFieldMnemonic(this LasSection lasSection)
+        {
+            return lasSection.GetMnemonic(MNEM_FLD);
+        }
+
+        public static LasMnemonicLine GetLocationMnemonic(this LasSection lasSection)
+        {
+            return lasSection.GetMnemonic(MNEM_LOC);
+        }
+
+        public static LasMnemonicLine GetProvinceMnemonic(this LasSection lasSection)
+        {
+            return lasSection.GetMnemonic(MNEM_PROV);
+        }
+
+        public static LasMnemonicLine GetCountyMnemonic(this LasSection lasSection)
+        {
+            return lasSection.GetMnemonic(MNEM_CNTY);
+        }
+
+        public static LasMnemonicLine GetStateMnemonic(this LasSection lasSection)
+        {
+            return lasSection.GetMnemonic(MNEM_STAT);
+        }
+
+        public static LasMnemonicLine GetCountryMnemonic(this LasSection lasSection)
+        {
+            return lasSection.GetMnemonic(MNEM_CTRY);
+        }
+
+        public static LasMnemonicLine GetServiceCompanyMnemonic(this LasSection lasSection)
+        {
+            return lasSection.GetMnemonic(MNEM_SRVC);
+        }
+
+        public static LasMnemonicLine GetDateMnemonic(this LasSection lasSection)
+        {
+            return lasSection.GetMnemonic(MNEM_DATE);
+        }
     }
 }

--- a/WellLog.Lib/Models/LasLog.cs
+++ b/WellLog.Lib/Models/LasLog.cs
@@ -12,6 +12,9 @@ namespace WellLog.Lib.Models
         [Key]
         public string WellIdentifier => this.WellIdentifier();
 
+        public bool UsesLineWrap => this.UsesLineWrap();
+        public LasFileVersion FileVersion => this.FileVersion();
+
         public LasSection VersionInformation => this.GetSection(LasSectionType.VersionInformation);
         public LasSection WellInformation => this.GetSection(LasSectionType.WellInformation);
         public LasSection CurveInformation => this.GetSection(LasSectionType.CurveInformation);

--- a/WellLog.Lib/WellLogModule.cs
+++ b/WellLog.Lib/WellLogModule.cs
@@ -14,6 +14,8 @@ namespace WellLog.Lib
             serviceCollection.AddScoped<ILasLogBusiness, LasLogBusiness>();
             serviceCollection.AddScoped<ILasSectionBusiness, LasSectionBusiness>();
             serviceCollection.AddScoped<ILasSectionLineBusiness, LasSectionLineBusiness>();
+            serviceCollection.AddScoped<IAsciiLogDataBusiness, AsciiLogDataBusiness>();
+            serviceCollection.AddScoped<IWellInformationBusiness, WellInformationBusiness>();
 
             /* Validators */
             serviceCollection.AddScoped<ILasLogValidator, LasLogValidator>();


### PR DESCRIPTION
added support for LAS file version 1.2.  the only practical difference between LAS file versions 1.2 and 2.0, from a file interpretation point of view, is how non-numeric data in the well information section is treated.  in LAS file version 1.2 the data section of the mnemonic line contains a label for the data while the description contains the data.  in LAS file version 2.0 this is reversed with the data section of the mnemonic line containing the data while the description contains the label.  i accounted for this by swapping the data and description sections, in memory, when and LAS version 1.2 file is detected.  i decided to swap the sections when interpreting LAS file version 1.2 because i felt the treatment of well information under the LAS file version 2.0 standard was more consistent with data in other sections of the file.