### PR TITLE
DLIS Representation Codes

### DIFF
--- a/WellLog.Lib.Test/Helpers/ByteHelpersHelpersTests.cs
+++ b/WellLog.Lib.Test/Helpers/ByteHelpersHelpersTests.cs
@@ -71,27 +71,5 @@ namespace WellLog.Lib.Test.Helpers
             byte expected = 0b_0010_0000;
             Assert.AreEqual(expected, b.ShiftRight(2));
         }
-
-        [Test]
-        public void ByteHelpers_ShiftRightArray_Pass_NullBytes()
-        {
-            byte[] bytes = null;
-            Assert.IsNull(bytes.ShiftRight());
-        }
-
-        [Test]
-        public void ByteHelpers_ShiftRightArray_Pass_ZeroBytes()
-        {
-            var bytes = new byte[0];
-            Assert.AreEqual(bytes, bytes.ShiftRight());
-        }
-
-        [Test]
-        public void ByteHelpers_ShiftRightArray_Pass()
-        {
-            var bytes = new byte[] { 0b_1000_0001, 0b_1000_0001 };
-            var expected = new byte[] { 0b_0100_0000, 0b_1100_0000 };
-            Assert.AreEqual(expected, bytes.ShiftRight());
-        }
     }
 }

--- a/WellLog.Lib.Test/Helpers/ByteHelpersHelpersTests.cs
+++ b/WellLog.Lib.Test/Helpers/ByteHelpersHelpersTests.cs
@@ -55,5 +55,65 @@ namespace WellLog.Lib.Test.Helpers
             byte attributeRole = 0b_0010_0000;
             Assert.IsFalse(setDescriptor.IsComponentRole(attributeRole));
         }
+
+        [Test]
+        public void ByteHelpers_ShiftLeftByte_Pass()
+        {
+            byte b = 0b_0000_0001;
+            byte expected = 0b_0000_0100;
+            Assert.AreEqual(expected, b.ShiftLeft(2));
+        }
+
+        [Test]
+        public void ByteHelpers_ShiftRightByte_Pass()
+        {
+            byte b = 0b_1000_0000;
+            byte expected = 0b_0010_0000;
+            Assert.AreEqual(expected, b.ShiftRight(2));
+        }
+
+        [Test]
+        public void ByteHelpers_ShiftLeftArray_Pass_NullBytes()
+        {
+            byte[] bytes = null;
+            Assert.IsNull(bytes.ShiftLeft());
+        }
+
+        [Test]
+        public void ByteHelpers_ShiftLeftArray_Pass_ZeroBytes()
+        {
+            var bytes = new byte[0];
+            Assert.AreEqual(bytes, bytes.ShiftLeft());
+        }
+
+        [Test]
+        public void ByteHelpers_ShiftLeftArray_Pass()
+        {
+            var bytes = new byte[] { 0b_1000_0001, 0b_1000_0001 };
+            var expected = new byte[] { 0b_0000_0011, 0b_0000_0010 };
+            Assert.AreEqual(expected, bytes.ShiftLeft());
+        }
+
+        [Test]
+        public void ByteHelpers_ShiftRightArray_Pass_NullBytes()
+        {
+            byte[] bytes = null;
+            Assert.IsNull(bytes.ShiftRight());
+        }
+
+        [Test]
+        public void ByteHelpers_ShiftRightArray_Pass_ZeroBytes()
+        {
+            var bytes = new byte[0];
+            Assert.AreEqual(bytes, bytes.ShiftRight());
+        }
+
+        [Test]
+        public void ByteHelpers_ShiftRightArray_Pass()
+        {
+            var bytes = new byte[] { 0b_1000_0001, 0b_1000_0001 };
+            var expected = new byte[] { 0b_0100_0000, 0b_1100_0000 };
+            Assert.AreEqual(expected, bytes.ShiftRight());
+        }
     }
 }

--- a/WellLog.Lib.Test/Helpers/ByteHelpersHelpersTests.cs
+++ b/WellLog.Lib.Test/Helpers/ByteHelpersHelpersTests.cs
@@ -41,19 +41,19 @@ namespace WellLog.Lib.Test.Helpers
         }
 
         [Test]
-        public void ByteHelpers_IsComponentRole_Pass_True()
+        public void ByteHelpers_HasDlisComponentRole_Pass_True()
         {
             byte attributeDescriptor = 0b_0011_1111;
             byte attributeRole = 0b_0010_0000;
-            Assert.IsTrue(attributeDescriptor.IsComponentRole(attributeRole));
+            Assert.IsTrue(attributeDescriptor.HasDlisComponentRole(attributeRole));
         }
 
         [Test]
-        public void ByteHelpers_IsComponentRole_Pass_False()
+        public void ByteHelpers_HasDlisComponentRole_Pass_False()
         {
             byte setDescriptor = 0b_1111_1000;
             byte attributeRole = 0b_0010_0000;
-            Assert.IsFalse(setDescriptor.IsComponentRole(attributeRole));
+            Assert.IsFalse(setDescriptor.HasDlisComponentRole(attributeRole));
         }
 
         [Test]
@@ -70,28 +70,6 @@ namespace WellLog.Lib.Test.Helpers
             byte b = 0b_1000_0000;
             byte expected = 0b_0010_0000;
             Assert.AreEqual(expected, b.ShiftRight(2));
-        }
-
-        [Test]
-        public void ByteHelpers_ShiftLeftArray_Pass_NullBytes()
-        {
-            byte[] bytes = null;
-            Assert.IsNull(bytes.ShiftLeft());
-        }
-
-        [Test]
-        public void ByteHelpers_ShiftLeftArray_Pass_ZeroBytes()
-        {
-            var bytes = new byte[0];
-            Assert.AreEqual(bytes, bytes.ShiftLeft());
-        }
-
-        [Test]
-        public void ByteHelpers_ShiftLeftArray_Pass()
-        {
-            var bytes = new byte[] { 0b_1000_0001, 0b_1000_0001 };
-            var expected = new byte[] { 0b_0000_0011, 0b_0000_0010 };
-            Assert.AreEqual(expected, bytes.ShiftLeft());
         }
 
         [Test]

--- a/WellLog.Lib.Test/Helpers/DlisStreamHelpersTest.cs
+++ b/WellLog.Lib.Test/Helpers/DlisStreamHelpersTest.cs
@@ -135,26 +135,56 @@ namespace WellLog.Lib.Test.Helpers
         }
 
         [Test]
+        public void DlisStreamHelpers_ReadISINGL_Pass_NullStream()
+        {
+            Assert.AreEqual(0f, nullStream.ReadISINGL());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadISINGL_Pass_EmptyStream()
+        {
+            var dlisStream = new MemoryStream();
+            Assert.AreEqual(0f, dlisStream.ReadISINGL());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadISINGL_Pass_ShortStream()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0xC2, 0x76, 0xA0 });
+            Assert.AreEqual(0f, dlisStream.ReadISINGL());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadISINGL_Pass_Positive()
+        {
+            var ibmFloats = new byte[]
+            {
+                0xC2, 0x76, 0xA0, 0x00,
+                0x42, 0x6C, 0xAD, 0x15
+            };
+            var dlisStream = new MemoryStream(ibmFloats);
+            Assert.AreEqual(-118.625f, dlisStream.ReadISINGL());
+            Assert.AreEqual(108.676102f, dlisStream.ReadISINGL());
+        }
+
+        [Test]
         public void DlisStreamHelpers_ReadVSINGL_Pass_NullStream()
         {
-            var expected = 0f;
-            Assert.AreEqual(expected, nullStream.ReadVSINGL());
+            Assert.AreEqual(0f, nullStream.ReadVSINGL());
         }
 
         [Test]
         public void DlisStreamHelpers_ReadVSINGL_Pass_EmptyStream()
         {
             var dlisStream = new MemoryStream();
-            var expected = 0f;
-            Assert.AreEqual(expected, dlisStream.ReadVSINGL());
+            Assert.AreEqual(0f, dlisStream.ReadVSINGL());
         }
 
         [Test]
         public void DlisStreamHelpers_ReadVSINGL_Pass_ShortStream()
         {
-            var dlisStream = new MemoryStream(new byte[] { 0b_0100_0000, 0b_0100_1001, 0b_0000_1111 });
-            var expected = 0f;
-            Assert.AreEqual(expected, dlisStream.ReadVSINGL());
+            var dlisStream = new MemoryStream(new byte[] { 0x80, 0x40, 0x00 });
+            Assert.AreEqual(0f, dlisStream.ReadVSINGL());
         }
 
         [Test]
@@ -177,20 +207,6 @@ namespace WellLog.Lib.Test.Helpers
 
             var dlisStream = new MemoryStream(vaxFloats);
 
-            /*
-             *  1.000000       00-00-40-80
-             * -1.000000       00-00-C0-80
-             *  3.500000       00-00-41-60
-             * -3.500000       00-00-C1-60
-             *  3.141590       0F-D0-41-49
-             * -3.141590       0F-D0-C1-49
-             *  9.9999999E+36  BD-C2-7D-F0
-             * -9.9999999E+36  BD-C2-FD-F0
-             *  9.9999999E-38  1C-EA-03-08
-             * -9.9999999E-38  1C-EA-83-08
-             *  1.23456788     06-52-40-9E
-             * -1.23456788     06-52-C0-9E
-             */
             Assert.AreEqual(1f, dlisStream.ReadVSINGL());
             Assert.AreEqual(-1f, dlisStream.ReadVSINGL());
             Assert.AreEqual(3.5f, dlisStream.ReadVSINGL());

--- a/WellLog.Lib.Test/Helpers/DlisStreamHelpersTest.cs
+++ b/WellLog.Lib.Test/Helpers/DlisStreamHelpersTest.cs
@@ -1,0 +1,526 @@
+﻿using NUnit.Framework;
+using System;
+using System.IO;
+using WellLog.Lib.Helpers;
+using WellLog.Lib.Models.DLIS;
+
+namespace WellLog.Lib.Test.Helpers
+{
+    [TestFixture]
+    public class DlisStreamHelpersTests
+    {
+        private static readonly MemoryStream nullStream = null;
+
+        [Test]
+        public void DlisStreamHelpers_ReadSSHORT_Pass_NullStream()
+        {
+            sbyte expected = 0;
+            Assert.AreEqual(expected, nullStream.ReadSSHORT());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadSSHORT_Pass_ShortStream()
+        {
+            var dlisStream = new MemoryStream(new byte[0]);
+            sbyte expected = 0;
+            Assert.AreEqual(expected, dlisStream.ReadSSHORT());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadSSHORT_Pass_Positive()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 127 });
+            sbyte expected = 127;
+            Assert.AreEqual(expected, dlisStream.ReadSSHORT());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadSSHORT_Pass_Negative()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_1111_1110 });
+            sbyte expected = -2;
+            Assert.AreEqual(expected, dlisStream.ReadSSHORT());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadSNORM_Pass_NullStream()
+        {
+            short expected = 0;
+            Assert.AreEqual(expected, nullStream.ReadSNORM());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadSNORM_Pass_ShortStream()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 255 });
+            short expected = 0;
+            Assert.AreEqual(expected, dlisStream.ReadSNORM());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadSNORM_Pass_Positive()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0000_0000, 0b_0000_0010 });
+            short expected = 2;
+            Assert.AreEqual(expected, dlisStream.ReadSNORM());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadSNORM_Pass_Negative()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_1111_1111, 0b_1111_1110 });
+            short expected = -2;
+            Assert.AreEqual(expected, dlisStream.ReadSNORM());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadSLONG_Pass_NullStream()
+        {
+            int expected = 0;
+            Assert.AreEqual(expected, nullStream.ReadSLONG());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadSLONG_Pass_ShortStream()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 255, 255, 255 });
+            int expected = 0;
+            Assert.AreEqual(expected, dlisStream.ReadSLONG());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadSLONG_Pass_Positive()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0000_0000, 0b_0000_0000, 0b_0000_0000, 0b_0000_0010 });
+            int expected = 2;
+            Assert.AreEqual(expected, dlisStream.ReadSLONG());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadSLONG_Pass_Negative()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_1111_1111, 0b_1111_1111, 0b_1111_1111, 0b_1111_1110 });
+            int expected = -2;
+            Assert.AreEqual(expected, dlisStream.ReadSLONG());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUSHORT_Pass_NullStream()
+        {
+            byte expected = 0;
+            Assert.AreEqual(expected, nullStream.ReadUSHORT());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUSHORT_Pass_ShortStream()
+        {
+            var dlisStream = new MemoryStream(new byte[0]);
+            byte expected = 0;
+            Assert.AreEqual(expected, dlisStream.ReadUSHORT());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUSHORT_Pass()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_1000_0000 });
+            byte expected = 128;
+            Assert.AreEqual(expected, dlisStream.ReadUSHORT());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUNORM_Pass_NullStream()
+        {
+            ushort expected = 0;
+            Assert.AreEqual(expected, nullStream.ReadUNORM());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUNORM_Pass_ShortStream()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 255 });
+            ushort expected = 0;
+            Assert.AreEqual(expected, dlisStream.ReadUNORM());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUNORM_Pass()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_1000_0000, 0b_0000_0000 });
+            ushort expected = 32768;
+            Assert.AreEqual(expected, dlisStream.ReadUNORM());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadULONG_Pass_NullStream()
+        {
+            uint expected = 0;
+            Assert.AreEqual(expected, nullStream.ReadULONG());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadULONG_Pass_ShortStream()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 255, 255, 255 });
+            uint expected = 0;
+            Assert.AreEqual(expected, dlisStream.ReadULONG());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadULONG_Pass_Positive()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_1000_0000, 0b_0000_0000, 0b_0000_0000, 0b_0000_0000 });
+            uint expected = 2147483648;
+            Assert.AreEqual(expected, dlisStream.ReadULONG());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUVARI1_Pass_NullStream()
+        {
+            uint expected = 0;
+            Assert.AreEqual(expected, nullStream.ReadUVARI1());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUVARI1_Pass_ShortStream()
+        {
+            var dlisStream = new MemoryStream(new byte[0]);
+            uint expected = 0;
+            Assert.AreEqual(expected, dlisStream.ReadUVARI1());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUVARI1_Pass()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0100_0000 });
+            uint expected = 64;
+            Assert.AreEqual(expected, dlisStream.ReadUVARI1());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUVARI2_Pass_NullStream()
+        {
+            uint expected = 0;
+            Assert.AreEqual(expected, nullStream.ReadUVARI2());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUVARI2_Pass_ShortStream()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_1000_1111 });
+            uint expected = 0;
+            Assert.AreEqual(expected, dlisStream.ReadUVARI2());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUVARI2_Pass()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_1000_0000, 0b_0100_0000 });
+            uint expected = 64;
+            Assert.AreEqual(expected, dlisStream.ReadUVARI2());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUVARI4_Pass_NullStream()
+        {
+            uint expected = 0;
+            Assert.AreEqual(expected, nullStream.ReadUVARI4());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUVARI4_Pass_ShortStream()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_1100_0000, 0b_1111_1111, 0b_1111_1111 });
+            uint expected = 0;
+            Assert.AreEqual(expected, dlisStream.ReadUVARI4());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUVARI4_Pass()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_1100_0000, 0b_0000_0000, 0b_0000_0000, 0b_0100_0000 });
+            uint expected = 64;
+            Assert.AreEqual(expected, dlisStream.ReadUVARI4());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUVARI_Pass_NullStream()
+        {
+            uint expected = 0;
+            Assert.AreEqual(expected, nullStream.ReadUVARI());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUVARI_Pass_UVARI1()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0100_0000 });
+            uint expected = 64;
+            Assert.AreEqual(expected, dlisStream.ReadUVARI());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUVARI_Pass_ShortUVARI2()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_1000_0001 });
+            uint expected = 0;
+            Assert.AreEqual(expected, dlisStream.ReadUVARI());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUVARI_Pass_UVARI2()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_1000_0001, 0b_0000_0000 });
+            uint expected = 256;
+            Assert.AreEqual(expected, dlisStream.ReadUVARI());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUVARI_Pass_ShortUVARI4()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_1100_0001, 0b_0000_0000, 0b_0000_0000 });
+            uint expected = 0;
+            Assert.AreEqual(expected, dlisStream.ReadUVARI());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUVARI_Pass_UVARI4()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_1100_0001, 0b_0000_0000, 0b_0000_0000, 0b_0000_0000 });
+            uint expected = 16777216;
+            Assert.AreEqual(expected, dlisStream.ReadUVARI());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadIDENT_Pass_NullStream()
+        {
+            Assert.IsNull(nullStream.ReadIDENT());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadIDENT_Pass_EmptyStream()
+        {
+            var dlisStream = new MemoryStream(new byte[0]);
+            Assert.IsNull(dlisStream.ReadIDENT());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadIDENT_Pass_NoChars()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0000_0000 });
+            Assert.AreEqual(string.Empty, dlisStream.ReadIDENT());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadIDENT_Pass_TooFewChars()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0000_0011, 0b_0100_0001, 0b_0100_0010 });
+            Assert.IsNull(dlisStream.ReadIDENT());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadIDENT_Pass()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0000_0011, 0b_0100_0001, 0b_0100_0010, 0b_0100_0011 });
+            string expected = "ABC";
+            Assert.AreEqual(expected, dlisStream.ReadIDENT());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadASCII_Pass_NullStream()
+        {
+            Assert.IsNull(nullStream.ReadASCII());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadASCII_Pass_EmptyStream()
+        {
+            var dlisStream = new MemoryStream();
+            Assert.IsNull(dlisStream.ReadASCII());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadASCII_Pass_NoChars()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0000_0000 });
+            Assert.AreEqual(string.Empty, dlisStream.ReadASCII());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadASCII_Pass_TooFewChars()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0000_0011, 0b_0100_0001, 0b_0100_0010 });
+            Assert.IsNull(dlisStream.ReadASCII());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadASCII_Pass()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0000_0011, 0b_0100_0001, 0b_0100_0010, 0b_0100_0011 });
+            string expected = "ABC";
+            Assert.AreEqual(expected, dlisStream.ReadASCII());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadDTIME_Pass_NullStream()
+        {
+            Assert.AreEqual(DateTime.MinValue, nullStream.ReadDTIME());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadDTIME_Pass_EmptyStream()
+        {
+            var dlisStream = new MemoryStream();
+            Assert.AreEqual(DateTime.MinValue, dlisStream.ReadDTIME());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadDTIME_Pass_ShortStream()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0000_0000 });
+            Assert.AreEqual(DateTime.MinValue, dlisStream.ReadDTIME());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadDTIME_Pass()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0101_0111, 0b_0001_0100, 0b_0001_0011, 0b_0001_0101, 0b_0001_0100, 0b_0000_1111, 0b_0000_0010, 0b_0110_1100 });
+            DateTime expected = new DateTime(1987, 4, 19, 21, 20, 15, 620, DateTimeKind.Local);
+            Assert.AreEqual(expected, dlisStream.ReadDTIME());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadOBNAME_Pass_NullStream()
+        {
+            Assert.IsNull(nullStream.ReadOBNAME());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadOBNAME_Pass_EmptyStream()
+        {
+            var dlisStream = new MemoryStream();
+            Assert.IsNull(dlisStream.ReadOBNAME());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadOBNAME_Pass()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0000_0001, 0b_0000_0010, 0b_0000_0001, 0b_0100_0001 });
+            var obName = dlisStream.ReadOBNAME();
+            Assert.AreEqual(1, obName.Origin);
+            Assert.AreEqual(2, obName.CopyNumber);
+            Assert.AreEqual("A", obName.Identifier);
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadOBJREF_Pass_NullStream()
+        {
+            Assert.IsNull(nullStream.ReadOBJREF());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadOBJREF_Pass_EmptyStream()
+        {
+            var dlisStream = new MemoryStream();
+            Assert.IsNull(dlisStream.ReadOBJREF());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadOBJREF_Pass()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0000_0001, 0b_0100_0001, 0b_0000_0001, 0b_0000_0010, 0b_0000_0001, 0b_0100_0010 });
+
+            var objRef = dlisStream.ReadOBJREF();
+            Assert.AreEqual("A", objRef.ObjectType);
+            Assert.AreEqual(1, objRef.Name.Origin);
+            Assert.AreEqual(2, objRef.Name.CopyNumber);
+            Assert.AreEqual("B", objRef.Name.Identifier);
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadATTREF_Pass_NullStream()
+        {
+            Assert.IsNull(nullStream.ReadATTREF());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadATTREF_Pass_EmptyStream()
+        {
+            var dlisStream = new MemoryStream();
+            Assert.IsNull(dlisStream.ReadATTREF());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadATTREF_Pass()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0000_0001, 0b_0100_0001, 0b_0000_0001, 0b_0000_0010, 0b_0000_0001, 0b_0100_0010, 0b_0000_0001, 0b_0100_0011 });
+
+            var attRef = dlisStream.ReadATTREF();
+            Assert.AreEqual("A", attRef.ObjectType);
+            Assert.AreEqual(1, attRef.Name.Origin);
+            Assert.AreEqual(2, attRef.Name.CopyNumber);
+            Assert.AreEqual("B", attRef.Name.Identifier);
+            Assert.AreEqual("C", attRef.Label);
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadSTATUS_Pass_NullStream()
+        {
+            Assert.IsFalse(nullStream.ReadSTATUS());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadSTATUS_Pass_EmptyStream()
+        {
+            var dlisStream = new MemoryStream();
+            Assert.IsFalse(dlisStream.ReadSTATUS());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadSTATUS_Pass_True()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0000_0001 });
+            Assert.IsTrue(dlisStream.ReadSTATUS());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadSTATUS_Pass_False()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0000_0000 });
+            Assert.IsFalse(dlisStream.ReadSTATUS());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUNITS_Pass_NullStream()
+        {
+            Assert.IsNull(nullStream.ReadUNITS());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUNITS_Pass_EmptyStream()
+        {
+            var dlisStream = new MemoryStream(new byte[0]);
+            Assert.IsNull(dlisStream.ReadUNITS());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUNITS_Pass_NoChars()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0000_0000 });
+            Assert.AreEqual(string.Empty, dlisStream.ReadUNITS());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUNITS_Pass_TooFewChars()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0000_0011, 0b_0100_0001, 0b_0100_0010 });
+            Assert.IsNull(dlisStream.ReadUNITS());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadUNITS_Pass()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0000_0011, 0b_0100_0001, 0b_0100_0010, 0b_0100_0011 });
+            string expected = "ABC";
+            Assert.AreEqual(expected, dlisStream.ReadUNITS());
+        }
+    }
+}

--- a/WellLog.Lib.Test/Helpers/DlisStreamHelpersTest.cs
+++ b/WellLog.Lib.Test/Helpers/DlisStreamHelpersTest.cs
@@ -12,6 +12,200 @@ namespace WellLog.Lib.Test.Helpers
         private static readonly MemoryStream nullStream = null;
 
         [Test]
+        public void DlisStreamHelpers_ReadFSHORT_Pass_NullStream()
+        {
+            var expected = 0f;
+            Assert.AreEqual(expected, nullStream.ReadFSHORT());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadFSHORT_Pass_EmptyStream()
+        {
+            var dlisStream = new MemoryStream();
+            var expected = 0f;
+            Assert.AreEqual(expected, dlisStream.ReadFSHORT());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadFSHORT_Pass_ShortStream()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0100_0000 });
+            var expected = 0f;
+            Assert.AreEqual(expected, dlisStream.ReadFSHORT());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadFSHORT_Pass_Positive()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0000_0000, 0b_0001_1000 });
+            var expected = 0.125f;
+            Assert.AreEqual(expected, dlisStream.ReadFSHORT());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadFSHORT_Pass_Negative()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_1111_1111, 0b_1111_1000 });
+            var expected = -0.125f;
+            Assert.AreEqual(expected, dlisStream.ReadFSHORT());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadFSINGL_Pass_NullStream()
+        {
+            var expected = 0f;
+            Assert.AreEqual(expected, nullStream.ReadFSINGL());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadFSINGL_Pass_EmptyStream()
+        {
+            var dlisStream = new MemoryStream();
+            var expected = 0f;
+            Assert.AreEqual(expected, dlisStream.ReadFSINGL());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadFSINGL_Pass_ShortStream()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0100_0000, 0b_0100_1001, 0b_0000_1111 });
+            var expected = 0f;
+            Assert.AreEqual(expected, dlisStream.ReadFSINGL());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadFSINGL_Pass_PositivePi()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0100_0000, 0b_0100_1001, 0b_0000_1111, 0b_1101_1011 });
+            var expected = 3.14159274f;
+            Assert.AreEqual(expected, dlisStream.ReadFSINGL());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadFSINGL_Pass_NegativePi()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_1100_0000, 0b_0100_1001, 0b_0000_1111, 0b_1101_1011 });
+            var expected = -3.14159274f;
+            Assert.AreEqual(expected, dlisStream.ReadFSINGL());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadFSING1_Pass_NullStream()
+        {
+            Assert.IsNull(nullStream.ReadFSING1());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadFSING1_Pass_EmptyStream()
+        {
+            var dlisStream = new MemoryStream();
+            Assert.IsNull(dlisStream.ReadFSING1());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadFSING1_Pass()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0100_0011, 0b_0001_1001, 0b_0000_0000, 0b_0000_0000, 0b_1100_0011, 0b_0001_1001, 0b_0000_0000, 0b_0000_0000 });
+            var fSing1 = dlisStream.ReadFSING1();
+            Assert.AreEqual(153f, fSing1.V);
+            Assert.AreEqual(-153f, fSing1.A);
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadFSING2_Pass_NullStream()
+        {
+            Assert.IsNull(nullStream.ReadFSING2());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadFSING2_Pass_EmptyStream()
+        {
+            var dlisStream = new MemoryStream();
+            Assert.IsNull(dlisStream.ReadFSING2());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadFSING2_Pass()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0100_0011, 0b_0001_1001, 0b_0000_0000, 0b_0000_0000, 0b_1100_0011, 0b_0001_1001, 0b_0000_0000, 0b_0000_0000, 0b_0100_0000, 0b_0100_1001, 0b_0000_1111, 0b_1101_1011 });
+            var fSing1 = dlisStream.ReadFSING2();
+            Assert.AreEqual(153f, fSing1.V);
+            Assert.AreEqual(-153f, fSing1.A);
+            Assert.AreEqual(3.14159274f, fSing1.B);
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadVSINGL_Pass_NullStream()
+        {
+            var expected = 0f;
+            Assert.AreEqual(expected, nullStream.ReadVSINGL());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadVSINGL_Pass_EmptyStream()
+        {
+            var dlisStream = new MemoryStream();
+            var expected = 0f;
+            Assert.AreEqual(expected, dlisStream.ReadVSINGL());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadVSINGL_Pass_ShortStream()
+        {
+            var dlisStream = new MemoryStream(new byte[] { 0b_0100_0000, 0b_0100_1001, 0b_0000_1111 });
+            var expected = 0f;
+            Assert.AreEqual(expected, dlisStream.ReadVSINGL());
+        }
+
+        [Test]
+        public void DlisStreamHelpers_ReadVSINGL_Pass_Positive()
+        {
+            var vaxFloats = new byte[] {
+                0x80, 0x40, 0x00, 0x00,
+                0x80, 0xC0, 0x00, 0x00,
+                0x60, 0x41, 0x00, 0x00,
+                0x60, 0xC1, 0x00, 0x00,
+                0x49, 0x41, 0xD0, 0x0F,
+                0x49, 0xC1, 0xD0, 0x0F,
+                0xF0, 0x7D, 0xC2, 0xBD,
+                0xF0, 0xFD, 0xC2, 0xBD,
+                0x08, 0x03, 0xEA, 0x1C,
+                0x08, 0x83, 0xEA, 0x1C,
+                0x9E, 0x40, 0x52, 0x06,
+                0x9E, 0xC0, 0x52, 0x06
+            };
+
+            var dlisStream = new MemoryStream(vaxFloats);
+
+            /*
+             *  1.000000       00-00-40-80
+             * -1.000000       00-00-C0-80
+             *  3.500000       00-00-41-60
+             * -3.500000       00-00-C1-60
+             *  3.141590       0F-D0-41-49
+             * -3.141590       0F-D0-C1-49
+             *  9.9999999E+36  BD-C2-7D-F0
+             * -9.9999999E+36  BD-C2-FD-F0
+             *  9.9999999E-38  1C-EA-03-08
+             * -9.9999999E-38  1C-EA-83-08
+             *  1.23456788     06-52-40-9E
+             * -1.23456788     06-52-C0-9E
+             */
+            Assert.AreEqual(1f, dlisStream.ReadVSINGL());
+            Assert.AreEqual(-1f, dlisStream.ReadVSINGL());
+            Assert.AreEqual(3.5f, dlisStream.ReadVSINGL());
+            Assert.AreEqual(-3.5f, dlisStream.ReadVSINGL());
+            Assert.AreEqual(3.14159f, dlisStream.ReadVSINGL());
+            Assert.AreEqual(-3.14159f, dlisStream.ReadVSINGL());
+            Assert.AreEqual(9.9999999E+36f, dlisStream.ReadVSINGL());
+            Assert.AreEqual(-9.9999999E+36f, dlisStream.ReadVSINGL());
+            Assert.AreEqual(9.9999999E-38f, dlisStream.ReadVSINGL());
+            Assert.AreEqual(-9.9999999E-38f, dlisStream.ReadVSINGL());
+            Assert.AreEqual(1.23456788f, dlisStream.ReadVSINGL());
+            Assert.AreEqual(-1.23456788f, dlisStream.ReadVSINGL());
+        }
+
+        [Test]
         public void DlisStreamHelpers_ReadSSHORT_Pass_NullStream()
         {
             sbyte expected = 0;
@@ -19,9 +213,9 @@ namespace WellLog.Lib.Test.Helpers
         }
 
         [Test]
-        public void DlisStreamHelpers_ReadSSHORT_Pass_ShortStream()
+        public void DlisStreamHelpers_ReadSSHORT_Pass_EmptyStream()
         {
-            var dlisStream = new MemoryStream(new byte[0]);
+            var dlisStream = new MemoryStream();
             sbyte expected = 0;
             Assert.AreEqual(expected, dlisStream.ReadSSHORT());
         }

--- a/WellLog.Lib.Test/Helpers/StreamHelpersTests.cs
+++ b/WellLog.Lib.Test/Helpers/StreamHelpersTests.cs
@@ -1,0 +1,104 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using WellLog.Lib.Helpers;
+
+namespace WellLog.Lib.Test.Helpers
+{
+    [TestFixture]
+    class StreamHelpersTests
+    {
+        private static readonly MemoryStream nullStream = null;
+
+        [Test]
+        public void StreamHelpers_ReadBytes_Pass_NullStream()
+        {
+            Assert.IsNull(nullStream.ReadBytes(1));
+        }
+
+        [Test]
+        public void StreamHelpers_ReadBytes_Pass_NegativeBytes()
+        {
+            var ms = new MemoryStream();
+            Assert.IsNull(ms.ReadBytes(-1));
+        }
+
+        [Test]
+        public void StreamHelpers_ReadBytes_Pass_ZeroBytes()
+        {
+            var ms = new MemoryStream();
+            Assert.AreEqual(0, ms.ReadBytes(0).Length);
+        }
+
+        [Test]
+        public void StreamHelpers_ReadBytes_Pass_ShortStream()
+        {
+            var ms = new MemoryStream(new byte[3] { 1, 2, 3 });
+            Assert.IsNull(ms.ReadBytes(4));
+        }
+
+        [Test]
+        public void StreamHelpers_ReadBytes_Pass()
+        {
+            var expected = new byte[4] { 1, 2, 3, 4 };
+            var ms = new MemoryStream(expected);
+            Assert.AreEqual(expected, ms.ReadBytes(4));
+        }
+
+        [Test]
+        public void StreamHelpers_IsAtEndOfStream_Pass_NullStream()
+        {
+            Assert.IsFalse(nullStream.IsAtEndOfStream());
+        }
+
+        [Test]
+        public void StreamHelpers_IsAtEndOfStream_Pass_EmptyStream()
+        {
+            var ms = new MemoryStream();
+            Assert.IsTrue(ms.IsAtEndOfStream());
+        }
+
+        [Test]
+        public void StreamHelpers_IsAtEndOfStream_Pass_BeginningOfStream()
+        {
+            var ms = new MemoryStream(new byte[] { 1, 2, 3 });
+            Assert.IsFalse(ms.IsAtEndOfStream());
+        }
+
+        [Test]
+        public void StreamHelpers_IsAtEndOfStream_Pass_SeekEndOfStream()
+        {
+            var ms = new MemoryStream(new byte[] { 1, 2, 3 });
+            ms.Seek(3, SeekOrigin.Begin);
+            Assert.IsTrue(ms.IsAtEndOfStream());
+        }
+
+        [Test]
+        public void StreamHelpers_IsAtEndOfStream_Pass_SeekNearEndOfStream()
+        {
+            var ms = new MemoryStream(new byte[] { 1, 2, 3 });
+            ms.Seek(2, SeekOrigin.Begin);
+            Assert.IsFalse(ms.IsAtEndOfStream());
+        }
+
+        [Test]
+        public void StreamHelpers_IsAtEndOfStream_Pass_ReadEndOfStream()
+        {
+            var ms = new MemoryStream(new byte[] { 1, 2, 3 });
+            var buffer = new byte[3];
+            ms.Read(buffer, 0, 3);
+            Assert.IsTrue(ms.IsAtEndOfStream());
+        }
+
+        [Test]
+        public void StreamHelpers_IsAtEndOfStream_Pass_ReadNearEndOfStream()
+        {
+            var ms = new MemoryStream(new byte[] { 1, 2, 3 });
+            var buffer = new byte[2];
+            ms.Read(buffer, 0, 2);
+            Assert.IsFalse(ms.IsAtEndOfStream());
+        }
+    }
+}

--- a/WellLog.Lib/Helpers/ByteHelpers.cs
+++ b/WellLog.Lib/Helpers/ByteHelpers.cs
@@ -28,5 +28,39 @@ namespace WellLog.Lib.Helpers
         {
             return (b >> 5) == (role >> 5);
         }
+
+        public static byte[] ShiftLeft(this byte[] bytes)
+        {
+            if (bytes == null) { return null; }
+
+            var buffer = new byte[bytes.Length];
+
+            var carryFlag = false;
+            for (int i = bytes.Length - 1; i >= 0; i--)
+            {
+                var b = bytes[i];
+                buffer[i] = Convert.ToByte(b << 1).AssignBitUsingMask(0b_0000_0001, carryFlag);
+                carryFlag = b.GetBitUsingMask(0b_1000_0000);
+            }
+
+            return buffer;
+        }
+
+        public static byte[] ShiftRight(this byte[] bytes)
+        {
+            if (bytes == null) { return null; }
+
+            var buffer = new byte[bytes.Length];
+
+            var carryFlag = false;
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                var b = bytes[i];
+                buffer[i] = Convert.ToByte(b >> 1).AssignBitUsingMask(0b_1000_0000, carryFlag);
+                carryFlag = b.GetBitUsingMask(0b_0000_0001);
+            }
+
+            return buffer;
+        }
     }
 }

--- a/WellLog.Lib/Helpers/ByteHelpers.cs
+++ b/WellLog.Lib/Helpers/ByteHelpers.cs
@@ -24,7 +24,7 @@ namespace WellLog.Lib.Helpers
             return value ? b.SetBitUsingMask(mask) : b.ClearBitUsingMask(mask);
         }
 
-        public static bool IsComponentRole(this byte b, byte role)
+        public static bool HasDlisComponentRole(this byte b, byte role)
         {
             return (b >> 5) == (role >> 5);
         }
@@ -37,101 +37,6 @@ namespace WellLog.Lib.Helpers
         public static byte ShiftRight(this byte b, byte p)
         {
             return BitConverter.GetBytes(b >> p)[0];
-        }
-
-        public static byte[] ShiftLeft(this byte[] bytes)
-        {
-            if (bytes == null) { return null; }
-
-            var n = bytes.Length;
-            if (n == 0) { return bytes; }
-
-            var buffer = new byte[n];
-
-            var carryFlag = false;
-            for (int i = n - 1; i >= 0; i--)
-            {
-                var b = bytes[i];
-                buffer[i] = b.ShiftLeft(1).AssignBitUsingMask(0b_0000_0001, carryFlag);
-                carryFlag = b.GetBitUsingMask(0b_1000_0000);
-            }
-
-            return buffer;
-        }
-
-        public static byte[] ShiftLeft(this byte[] bytes, byte p)
-        {
-            if (bytes == null) { return null; }
-            if (p < 1) { return bytes; }
-
-            var n = bytes.Length;
-            if (n == 0) { return bytes; }
-
-            var buffer = bytes.ShiftLeft();
-            for (var i = 1; i < p; i++) { buffer = buffer.ShiftLeft(); }
-
-            return buffer;
-        }
-
-        public static byte[] ShiftRight(this byte[] bytes)
-        {
-            if (bytes == null) { return null; }
-
-            var n = bytes.Length;
-            if (n == 0) { return new byte[0]; }
-
-            var buffer = new byte[n];
-
-            var carryFlag = false;
-            for (int i = 0; i < n; i++)
-            {
-                var b = bytes[i];
-                buffer[i] = b.ShiftRight(1).AssignBitUsingMask(0b_1000_0000, carryFlag);
-                carryFlag = b.GetBitUsingMask(0b_0000_0001);
-            }
-
-            return buffer;
-        }
-
-        public static byte[] ShiftRight(this byte[] bytes, byte p)
-        {
-            if (bytes == null) { return null; }
-            if (p < 1) { return bytes; }
-
-            var n = bytes.Length;
-            if (n == 0) { return bytes; }
-
-            var buffer = bytes.ShiftRight();
-            for (var i = 1; i < p; i++) { buffer = buffer.ShiftRight(); }
-
-            return buffer;
-        }
-
-        public static string ToBinaryString(this byte b)
-        {
-            var response = new char[8];
-            for(var i = 0; i < 8; i++)
-            {
-                response[i] = b.GetBitUsingMask(0b_1000_0000) ? '1' : '0';
-                b = b.ShiftLeft(1);
-            }
-            return new string(response);
-        }
-
-        public static string ToBinaryString(this byte[] bytes)
-        {
-            if (bytes == null) { return null; }
-
-            var n = bytes.Length;
-            if (n == 0) { return string.Empty; }
-
-            var buffer = new string[n];
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                buffer[i] = bytes[i].ToBinaryString();
-            }
-
-            return string.Join(' ', buffer);
         }
 
         public static byte[] Reversed(this byte[] buffer)

--- a/WellLog.Lib/Helpers/ByteHelpers.cs
+++ b/WellLog.Lib/Helpers/ByteHelpers.cs
@@ -44,7 +44,7 @@ namespace WellLog.Lib.Helpers
             if (bytes == null) { return null; }
 
             var n = bytes.Length;
-            if (n == 0) { return new byte[0]; }
+            if (n == 0) { return bytes; }
 
             var buffer = new byte[n];
 
@@ -55,6 +55,20 @@ namespace WellLog.Lib.Helpers
                 buffer[i] = b.ShiftLeft(1).AssignBitUsingMask(0b_0000_0001, carryFlag);
                 carryFlag = b.GetBitUsingMask(0b_1000_0000);
             }
+
+            return buffer;
+        }
+
+        public static byte[] ShiftLeft(this byte[] bytes, byte p)
+        {
+            if (bytes == null) { return null; }
+            if (p < 1) { return bytes; }
+
+            var n = bytes.Length;
+            if (n == 0) { return bytes; }
+
+            var buffer = bytes.ShiftLeft();
+            for (var i = 1; i < p; i++) { buffer = buffer.ShiftLeft(); }
 
             return buffer;
         }
@@ -75,6 +89,20 @@ namespace WellLog.Lib.Helpers
                 buffer[i] = b.ShiftRight(1).AssignBitUsingMask(0b_1000_0000, carryFlag);
                 carryFlag = b.GetBitUsingMask(0b_0000_0001);
             }
+
+            return buffer;
+        }
+
+        public static byte[] ShiftRight(this byte[] bytes, byte p)
+        {
+            if (bytes == null) { return null; }
+            if (p < 1) { return bytes; }
+
+            var n = bytes.Length;
+            if (n == 0) { return bytes; }
+
+            var buffer = bytes.ShiftRight();
+            for (var i = 1; i < p; i++) { buffer = buffer.ShiftRight(); }
 
             return buffer;
         }
@@ -136,7 +164,7 @@ namespace WellLog.Lib.Helpers
             if (buffer == null) { return 0; }
             if (buffer.Length < 2) { return 0; }
             if (BitConverter.IsLittleEndian != isLittleEndian) { return BitConverter.ToUInt16(buffer[0..2].Reversed()); }
-            return BitConverter.ToUInt16(buffer);
+            return BitConverter.ToUInt16(buffer[0..2]);
         }
 
         public static short ConvertToShort(this byte[] buffer, bool isLittleEndian = true)
@@ -144,15 +172,15 @@ namespace WellLog.Lib.Helpers
             if (buffer == null) { return 0; }
             if (buffer.Length < 2) { return 0; }
             if (BitConverter.IsLittleEndian != isLittleEndian) { return BitConverter.ToInt16(buffer[0..2].Reversed()); }
-            return BitConverter.ToInt16(buffer);
+            return BitConverter.ToInt16(buffer[0..2]);
         }
 
         public static uint ConvertToUInt(this byte[] buffer, bool isLittleEndian = true)
         {
-            if (buffer == null) { return 0; }
-            if (buffer.Length < 4) { return 0; }
+            if (buffer == null) { return 0u; }
+            if (buffer.Length < 4) { return 0u; }
             if (BitConverter.IsLittleEndian != isLittleEndian) { return BitConverter.ToUInt32(buffer[0..4].Reversed()); }
-            return BitConverter.ToUInt16(buffer);
+            return BitConverter.ToUInt16(buffer[0..4]);
         }
 
         public static int ConvertToInt(this byte[] buffer, bool isLittleEndian = true)
@@ -160,7 +188,23 @@ namespace WellLog.Lib.Helpers
             if (buffer == null) { return 0; }
             if (buffer.Length < 4) { return 0; }
             if (BitConverter.IsLittleEndian != isLittleEndian) { return BitConverter.ToInt32(buffer[0..4].Reversed()); }
-            return BitConverter.ToInt32(buffer);
+            return BitConverter.ToInt32(buffer[0..4]);
+        }
+
+        public static float ConvertToFloat(this byte[] buffer, bool isLittleEndian = true)
+        {
+            if (buffer == null) { return 0f; }
+            if (buffer.Length < 4) { return 0f; }
+            if (BitConverter.IsLittleEndian != isLittleEndian) { return BitConverter.ToSingle(buffer[0..4].Reversed()); }
+            return BitConverter.ToSingle(buffer[0..4]);
+        }
+
+        public static double ConvertToDouble(this byte[] buffer, bool isLittleEndian = true)
+        {
+            if (buffer == null) { return 0d; }
+            if (buffer.Length < 8) { return 0d; }
+            if (BitConverter.IsLittleEndian != isLittleEndian) { return BitConverter.ToDouble(buffer[0..8].Reversed()); }
+            return BitConverter.ToDouble(buffer[0..8]);
         }
     }
 }

--- a/WellLog.Lib/Helpers/ByteHelpers.cs
+++ b/WellLog.Lib/Helpers/ByteHelpers.cs
@@ -29,17 +29,30 @@ namespace WellLog.Lib.Helpers
             return (b >> 5) == (role >> 5);
         }
 
+        public static byte ShiftLeft(this byte b, byte p)
+        {
+            return BitConverter.GetBytes(b << p)[0];
+        }
+
+        public static byte ShiftRight(this byte b, byte p)
+        {
+            return BitConverter.GetBytes(b >> p)[0];
+        }
+
         public static byte[] ShiftLeft(this byte[] bytes)
         {
             if (bytes == null) { return null; }
 
-            var buffer = new byte[bytes.Length];
+            var n = bytes.Length;
+            if (n == 0) { return new byte[0]; }
+
+            var buffer = new byte[n];
 
             var carryFlag = false;
-            for (int i = bytes.Length - 1; i >= 0; i--)
+            for (int i = n - 1; i >= 0; i--)
             {
                 var b = bytes[i];
-                buffer[i] = Convert.ToByte(b << 1).AssignBitUsingMask(0b_0000_0001, carryFlag);
+                buffer[i] = b.ShiftLeft(1).AssignBitUsingMask(0b_0000_0001, carryFlag);
                 carryFlag = b.GetBitUsingMask(0b_1000_0000);
             }
 
@@ -50,17 +63,104 @@ namespace WellLog.Lib.Helpers
         {
             if (bytes == null) { return null; }
 
-            var buffer = new byte[bytes.Length];
+            var n = bytes.Length;
+            if (n == 0) { return new byte[0]; }
+
+            var buffer = new byte[n];
 
             var carryFlag = false;
-            for (int i = 0; i < bytes.Length; i++)
+            for (int i = 0; i < n; i++)
             {
                 var b = bytes[i];
-                buffer[i] = Convert.ToByte(b >> 1).AssignBitUsingMask(0b_1000_0000, carryFlag);
+                buffer[i] = b.ShiftRight(1).AssignBitUsingMask(0b_1000_0000, carryFlag);
                 carryFlag = b.GetBitUsingMask(0b_0000_0001);
             }
 
             return buffer;
+        }
+
+        public static string ToBinaryString(this byte b)
+        {
+            var response = new char[8];
+            for(var i = 0; i < 8; i++)
+            {
+                response[i] = b.GetBitUsingMask(0b_1000_0000) ? '1' : '0';
+                b = b.ShiftLeft(1);
+            }
+            return new string(response);
+        }
+
+        public static string ToBinaryString(this byte[] bytes)
+        {
+            if (bytes == null) { return null; }
+
+            var n = bytes.Length;
+            if (n == 0) { return string.Empty; }
+
+            var buffer = new string[n];
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                buffer[i] = bytes[i].ToBinaryString();
+            }
+
+            return string.Join(' ', buffer);
+        }
+
+        public static byte[] Reversed(this byte[] buffer)
+        {
+            if (buffer == null) { return null; }
+            if (buffer.Length < 2) { return buffer; }
+
+            var newBuffer = new byte[buffer.Length];
+            buffer.CopyTo(newBuffer, 0);
+            Array.Reverse(newBuffer);
+            return newBuffer;
+        }
+
+        public static byte ConvertToByte(this byte[] buffer)
+        {
+            if (buffer == null) { return 0; }
+            if (buffer.Length < 1) { return 0; }
+            return buffer[0];
+        }
+
+        public static sbyte ConvertToSbyte(this byte[] buffer)
+        {
+            if (buffer == null) { return 0; }
+            if (buffer.Length < 1) { return 0; }
+            return (sbyte)buffer[0];
+        }
+
+        public static ushort ConvertToUshort(this byte[] buffer, bool isLittleEndian = true)
+        {
+            if (buffer == null) { return 0; }
+            if (buffer.Length < 2) { return 0; }
+            if (BitConverter.IsLittleEndian != isLittleEndian) { return BitConverter.ToUInt16(buffer[0..2].Reversed()); }
+            return BitConverter.ToUInt16(buffer);
+        }
+
+        public static short ConvertToShort(this byte[] buffer, bool isLittleEndian = true)
+        {
+            if (buffer == null) { return 0; }
+            if (buffer.Length < 2) { return 0; }
+            if (BitConverter.IsLittleEndian != isLittleEndian) { return BitConverter.ToInt16(buffer[0..2].Reversed()); }
+            return BitConverter.ToInt16(buffer);
+        }
+
+        public static uint ConvertToUInt(this byte[] buffer, bool isLittleEndian = true)
+        {
+            if (buffer == null) { return 0; }
+            if (buffer.Length < 4) { return 0; }
+            if (BitConverter.IsLittleEndian != isLittleEndian) { return BitConverter.ToUInt32(buffer[0..4].Reversed()); }
+            return BitConverter.ToUInt16(buffer);
+        }
+
+        public static int ConvertToInt(this byte[] buffer, bool isLittleEndian = true)
+        {
+            if (buffer == null) { return 0; }
+            if (buffer.Length < 4) { return 0; }
+            if (BitConverter.IsLittleEndian != isLittleEndian) { return BitConverter.ToInt32(buffer[0..4].Reversed()); }
+            return BitConverter.ToInt32(buffer);
         }
     }
 }

--- a/WellLog.Lib/Helpers/DlisStreamHelpers.cs
+++ b/WellLog.Lib/Helpers/DlisStreamHelpers.cs
@@ -14,24 +14,19 @@ namespace WellLog.Lib.Helpers
             var buffer = dlisStream.ReadBytes(2);
             if (buffer == null) { return 0f; }
 
-            var floatBuffer = new byte[4]
-            {
-                buffer[1].ClearBitUsingMask(0b_1111_0000),
-                buffer[0],
-                buffer[1].ClearBitUsingMask(0b_0000_1111),
-                0
-            };
-            return BitConverter.ToSingle(floatBuffer.ShiftRight());
+            var sign = buffer[0].GetBitUsingMask(0b_1000_0000);
+            var mantissaBuffer = buffer.ShiftRight(4);
+            mantissaBuffer[0] = mantissaBuffer[0].AssignBitUsingMask(0b_1111_0000, sign);
+
+            var mantissa = mantissaBuffer.ConvertToShort(false);
+            var exponent = buffer[1].ClearBitUsingMask(0b_1111_0000);
+            return Convert.ToSingle(mantissa << exponent) / 2048f;
         }
 
         public static float ReadFSINGL(this Stream dlisStream)
         {
             if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return 0f; }
-
-            var buffer = dlisStream.ReadBytes(4);
-            if (buffer == null) { return 0f; }
-
-            return BitConverter.ToSingle(buffer);
+            return dlisStream.ReadBytes(4).ConvertToFloat(false);
         }
 
         public static FSING1 ReadFSING1(this Stream dlisStream)
@@ -55,6 +50,12 @@ namespace WellLog.Lib.Helpers
             };
         }
 
+        public static uint IBM_SIGN_MASK = 0x80000000;
+        public static int IBM_EXPONENT_MASK = 0x7F000000;
+        public static int IBM_EXPONENT_SIZE = 7;
+        public static int IBM_MANTISSA_MASK = 0x00FFFFFF;
+        public static int IBM_MANTISSA_SIZE = 24;
+
         public static float ReadISINGL(this Stream dlisStream)
         {
             if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return 0f; }
@@ -62,13 +63,24 @@ namespace WellLog.Lib.Helpers
             var buffer = dlisStream.ReadBytes(4);
             if (buffer == null) { return 0f; }
 
-            var sign = buffer[0].GetBitUsingMask(0b_1000_0000);
-            buffer[0] = buffer[0].ClearBitUsingMask(0b_1000_0000);
-            buffer = buffer.ShiftRight();
-            buffer[0] = buffer[0].AssignBitUsingMask(0b_1000_0000, sign);
+            var ibmData = buffer.ConvertToInt(false);
+            var sign = ibmData & (int)IBM_SIGN_MASK;
+            var exponent = ibmData & IBM_EXPONENT_MASK;
+            var mantissa = ibmData & IBM_MANTISSA_MASK;
 
-            return BitConverter.ToSingle(buffer);
+            exponent >>= 1;
+            mantissa >>= 1;
+
+            return BitConverter.GetBytes(sign | exponent | mantissa).ConvertToFloat();
         }
+
+        public static uint VAX_SIGN_MASK = 0x80000000;
+        public static int VAX_EXPONENT_MASK = 0x7F800000;
+        public static int VAX_MANTISSA_MASK = 0x007FFFFF;
+        public static int VAX_MANTISSA_SIZE = 23;
+        public static int VAX_EXPONENT_ADJUSTMENT = 2;
+        public static int VAX_IN_PLACE_EXPONENT_ADJUSTMENT = 16777216;
+        public static int VAX_HIDDEN_BIT = 0x00800000;
 
         public static float ReadVSINGL(this Stream dlisStream)
         {
@@ -77,17 +89,43 @@ namespace WellLog.Lib.Helpers
             var buffer = dlisStream.ReadBytes(4);
             if (buffer == null) { return 0f; }
 
-            return BitConverter.ToSingle(new byte[4] { buffer[1], buffer[0], buffer[2], buffer[3] });
+            var vaxData = (new byte[] { buffer[1], buffer[0], buffer[3], buffer[2] }).ConvertToInt(false);
+
+            var exponent = vaxData & VAX_EXPONENT_MASK;
+            if (exponent == 0) { return 0f; }
+            exponent >>= VAX_MANTISSA_SIZE;
+
+            /* The biased VAX exponent has to be adjusted to account for the right shift of the
+             * IEEE mantissa binary point and the difference betweenthe biases in their "excess n"
+             * exponent representations.  If the resulting biased IEEE exponent is less than or
+             * equal to zero, the converted IEEE S_float must use subnormal form.
+             * - Lawrence M. Baker
+             * https://pubs.usgs.gov/of/2005/1424/
+             */
+            exponent -= VAX_EXPONENT_ADJUSTMENT;
+            if (exponent > 0)
+            {
+                return BitConverter.GetBytes(vaxData - VAX_IN_PLACE_EXPONENT_ADJUSTMENT).ConvertToFloat();
+            }
+
+            /* In IEEE subnormal form, even though the biased exponent is 0 [e=0], the effective
+             * biased exponent is 1.  The mantissa must be shifted right by the number of bits, n,
+             * required to adjust the biased exponent from its current value, e, to 1
+             * (i.e. e + n = 1, thus n = 1 - e).
+             * n is guaranteed to be at least 1 [e<=0], which guarantees that the hidden 1.m bit
+             * from the original mantissa will become visible, and the resulting subnormal
+             * mantissa will correctly be of the form 0.m.
+             * - Lawrence M. Baker
+             * https://pubs.usgs.gov/of/2005/1424/
+             */
+            vaxData = (vaxData & (int)VAX_SIGN_MASK) | ((VAX_HIDDEN_BIT | (vaxData & VAX_MANTISSA_MASK)) >> (1 - exponent));
+            return BitConverter.GetBytes(vaxData).ConvertToFloat();
         }
 
         public static double ReadFDOUBL(this Stream dlisStream)
         {
             if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return 0d; }
-
-            var buffer = dlisStream.ReadBytes(8);
-            if (buffer == null) { return 0d; }
-
-            return BitConverter.ToDouble(buffer);
+            return dlisStream.ReadBytes(8).ConvertToDouble(false);
         }
 
         public static FDOUB1 ReadFDOUB1(this Stream dlisStream)

--- a/WellLog.Lib/Helpers/DlisStreamHelpers.cs
+++ b/WellLog.Lib/Helpers/DlisStreamHelpers.cs
@@ -1,0 +1,281 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using WellLog.Lib.Models.DLIS;
+
+namespace WellLog.Lib.Helpers
+{
+    public static class DlisStreamHelpers
+    {
+        public static byte[] ReadBytes(this Stream dlisStream, int numBytes)
+        {
+            if (dlisStream == null) { return null; }
+
+            var buffer = new byte[numBytes];
+            var bytesRead = dlisStream.Read(buffer, 0, numBytes);
+
+            if (bytesRead < numBytes) { return null; }
+            return buffer;
+        }
+
+        public static float ReadFSHORT(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return 0f; }
+
+            var buffer = dlisStream.ReadBytes(2);
+            if (buffer == null) { return 0f; }
+
+            var floatBuffer = new byte[4]
+            {
+                buffer[1].ClearBitUsingMask(0b_1111_0000),
+                buffer[0],
+                buffer[1].ClearBitUsingMask(0b_0000_1111),
+                0
+            };
+            return BitConverter.ToSingle(floatBuffer.ShiftRight());
+        }
+
+        public static float ReadFSINGL(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return 0f; }
+
+            var buffer = dlisStream.ReadBytes(4);
+            if (buffer == null) { return 0f; }
+
+            return BitConverter.ToSingle(buffer);
+        }
+
+        public static FSING1 ReadFSING1(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return null; }
+            return new FSING1
+            {
+                V = dlisStream.ReadFSINGL(),
+                A = dlisStream.ReadFSINGL()
+            };
+        }
+
+        public static FSING2 ReadFSING2(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return null; }
+            return new FSING2
+            {
+                V = dlisStream.ReadFSINGL(),
+                A = dlisStream.ReadFSINGL(),
+                B = dlisStream.ReadFSINGL()
+            };
+        }
+
+        public static float ReadISINGL(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return 0f; }
+
+            var buffer = dlisStream.ReadBytes(4);
+            if (buffer == null) { return 0f; }
+
+            var sign = buffer[0].GetBitUsingMask(0b_1000_0000);
+            buffer[0] = buffer[0].ClearBitUsingMask(0b_1000_0000);
+            buffer = buffer.ShiftRight();
+            buffer[0] = buffer[0].AssignBitUsingMask(0b_1000_0000, sign);
+
+            return BitConverter.ToSingle(buffer);
+        }
+
+        public static float ReadVSINGL(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return 0f; }
+
+            var buffer = dlisStream.ReadBytes(4);
+            if (buffer == null) { return 0f; }
+
+            return BitConverter.ToSingle(new byte[4] { buffer[1], buffer[0], buffer[2], buffer[3] });
+        }
+
+        public static double ReadFDOUBL(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return 0d; }
+
+            var buffer = dlisStream.ReadBytes(8);
+            if (buffer == null) { return 0d; }
+
+            return BitConverter.ToDouble(buffer);
+        }
+
+        public static FDOUB1 ReadFDOUB1(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return null; }
+            return new FDOUB1
+            {
+                V = dlisStream.ReadFDOUBL(),
+                A = dlisStream.ReadFDOUBL()
+            };
+        }
+
+        public static FDOUB2 ReadFDOUB2(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return null; }
+            return new FDOUB2
+            {
+                V = dlisStream.ReadFDOUBL(),
+                A = dlisStream.ReadFDOUBL(),
+                B = dlisStream.ReadFDOUBL()
+            };
+        }
+
+        public static CSINGL ReadCSINGL(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return null; }
+            return new CSINGL
+            {
+                R = dlisStream.ReadFSINGL(),
+                I = dlisStream.ReadFSINGL()
+            };
+        }
+
+        public static CDOUBL ReadCDOUBL(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return null; }
+            return new CDOUBL
+            {
+                R = dlisStream.ReadFDOUBL(),
+                I = dlisStream.ReadFDOUBL()
+            };
+        }
+
+        public static sbyte ReadSSHORT(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return 0; }
+            return Convert.ToSByte(dlisStream.ReadByte());
+        }
+
+        public static short ReadSNORM(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return 0; }
+            return BitConverter.ToInt16(dlisStream.ReadBytes(2));
+        }
+
+        public static int ReadSLONG(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return 0; }
+            return BitConverter.ToInt32(dlisStream.ReadBytes(4));
+        }
+
+        public static byte ReadUSHORT(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return 0; }
+            return Convert.ToByte(dlisStream.ReadByte());
+        }
+
+        public static ushort ReadUNORM(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return 0; }
+            return BitConverter.ToUInt16(dlisStream.ReadBytes(2));
+        }
+
+        public static uint ReadULONG(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return 0; }
+            return BitConverter.ToUInt32(dlisStream.ReadBytes(4));
+        }
+
+        public static uint ReadUVARI(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return 0; }
+
+            var b = Convert.ToByte(dlisStream.ReadByte());
+            if (b >> 7 == 0) { return Convert.ToUInt32(b); }
+            if (b >> 6 == 2) { return BitConverter.ToUInt32(new byte[2] { b.ClearBitUsingMask(0b_1000_0000), Convert.ToByte(dlisStream.ReadByte()) }); }
+            if (b >> 6 == 3)
+            {
+                var buffer = dlisStream.ReadBytes(3);
+                return BitConverter.ToUInt32(new byte[4] { b.ClearBitUsingMask(0b_1100_0000), buffer[0], buffer[1], buffer[2] });
+            }
+
+            return BitConverter.ToUInt32(dlisStream.ReadBytes(4));
+        }
+
+        public static string ReadIDENT(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return null; }
+
+            var length = dlisStream.ReadByte();
+            if (length < 0) { return null; }
+
+            return Encoding.ASCII.GetString(dlisStream.ReadBytes(length));
+        }
+
+        public static string ReadASCII(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return null; }
+
+            var length = Convert.ToInt32(dlisStream.ReadUVARI());
+            if (length < 0) { return null; }
+
+            return Encoding.ASCII.GetString(dlisStream.ReadBytes(length));
+        }
+
+        public static DateTime ReadDTIME(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return DateTime.MinValue; }
+
+            var buffer = dlisStream.ReadBytes(8);
+            var year = 1900 + buffer[0];
+            var month = buffer[1].ClearBitUsingMask(0b_1111_0000);
+            var day = buffer[2];
+            var hour = buffer[3];
+            var minute = buffer[4];
+            var second = buffer[5];
+            var millisecond = BitConverter.ToUInt16(new byte[2] { buffer[6], buffer[7] });
+
+            return new DateTime(year, month, day, hour, minute, second, millisecond);
+        }
+
+        public static OBNAME ReadOBNAME(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return null; }
+            return new OBNAME
+            {
+                O = dlisStream.ReadUVARI(),
+                C = dlisStream.ReadUSHORT(),
+                I = dlisStream.ReadIDENT()
+            };
+        }
+
+        public static OBJREF ReadOBJREF(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return null; }
+            return new OBJREF
+            {
+                T = dlisStream.ReadIDENT(),
+                N = dlisStream.ReadOBNAME()
+            };
+        }
+
+        public static ATTREF ReadATTREF(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return null; }
+            return new ATTREF
+            {
+                T = dlisStream.ReadIDENT(),
+                N = dlisStream.ReadOBNAME(),
+                L = dlisStream.ReadIDENT()
+            };
+        }
+
+        public static bool ReadSTATUS(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return false; }
+            return dlisStream.ReadUSHORT() != 0;
+        }
+
+        public static string ReadUNITS(this Stream dlisStream)
+        {
+            if (dlisStream == null) { return null; }
+
+            var length = Convert.ToInt32(dlisStream.ReadUSHORT());
+            if (length < 0) { return null; }
+
+            return Encoding.ASCII.GetString(dlisStream.ReadBytes(length));
+        }
+    }
+}

--- a/WellLog.Lib/Helpers/DlisStreamHelpers.cs
+++ b/WellLog.Lib/Helpers/DlisStreamHelpers.cs
@@ -7,20 +7,9 @@ namespace WellLog.Lib.Helpers
 {
     public static class DlisStreamHelpers
     {
-        public static byte[] ReadBytes(this Stream dlisStream, int numBytes)
-        {
-            if (dlisStream == null) { return null; }
-
-            var buffer = new byte[numBytes];
-            var bytesRead = dlisStream.Read(buffer, 0, numBytes);
-
-            if (bytesRead < numBytes) { return null; }
-            return buffer;
-        }
-
         public static float ReadFSHORT(this Stream dlisStream)
         {
-            if (dlisStream == null) { return 0f; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return 0f; }
 
             var buffer = dlisStream.ReadBytes(2);
             if (buffer == null) { return 0f; }
@@ -37,7 +26,7 @@ namespace WellLog.Lib.Helpers
 
         public static float ReadFSINGL(this Stream dlisStream)
         {
-            if (dlisStream == null) { return 0f; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return 0f; }
 
             var buffer = dlisStream.ReadBytes(4);
             if (buffer == null) { return 0f; }
@@ -47,7 +36,7 @@ namespace WellLog.Lib.Helpers
 
         public static FSING1 ReadFSING1(this Stream dlisStream)
         {
-            if (dlisStream == null) { return null; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return null; }
             return new FSING1
             {
                 V = dlisStream.ReadFSINGL(),
@@ -57,7 +46,7 @@ namespace WellLog.Lib.Helpers
 
         public static FSING2 ReadFSING2(this Stream dlisStream)
         {
-            if (dlisStream == null) { return null; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return null; }
             return new FSING2
             {
                 V = dlisStream.ReadFSINGL(),
@@ -68,7 +57,7 @@ namespace WellLog.Lib.Helpers
 
         public static float ReadISINGL(this Stream dlisStream)
         {
-            if (dlisStream == null) { return 0f; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return 0f; }
 
             var buffer = dlisStream.ReadBytes(4);
             if (buffer == null) { return 0f; }
@@ -83,7 +72,7 @@ namespace WellLog.Lib.Helpers
 
         public static float ReadVSINGL(this Stream dlisStream)
         {
-            if (dlisStream == null) { return 0f; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return 0f; }
 
             var buffer = dlisStream.ReadBytes(4);
             if (buffer == null) { return 0f; }
@@ -93,7 +82,7 @@ namespace WellLog.Lib.Helpers
 
         public static double ReadFDOUBL(this Stream dlisStream)
         {
-            if (dlisStream == null) { return 0d; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return 0d; }
 
             var buffer = dlisStream.ReadBytes(8);
             if (buffer == null) { return 0d; }
@@ -103,7 +92,7 @@ namespace WellLog.Lib.Helpers
 
         public static FDOUB1 ReadFDOUB1(this Stream dlisStream)
         {
-            if (dlisStream == null) { return null; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return null; }
             return new FDOUB1
             {
                 V = dlisStream.ReadFDOUBL(),
@@ -113,7 +102,7 @@ namespace WellLog.Lib.Helpers
 
         public static FDOUB2 ReadFDOUB2(this Stream dlisStream)
         {
-            if (dlisStream == null) { return null; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return null; }
             return new FDOUB2
             {
                 V = dlisStream.ReadFDOUBL(),
@@ -124,7 +113,7 @@ namespace WellLog.Lib.Helpers
 
         public static CSINGL ReadCSINGL(this Stream dlisStream)
         {
-            if (dlisStream == null) { return null; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return null; }
             return new CSINGL
             {
                 R = dlisStream.ReadFSINGL(),
@@ -134,7 +123,7 @@ namespace WellLog.Lib.Helpers
 
         public static CDOUBL ReadCDOUBL(this Stream dlisStream)
         {
-            if (dlisStream == null) { return null; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return null; }
             return new CDOUBL
             {
                 R = dlisStream.ReadFDOUBL(),
@@ -144,138 +133,184 @@ namespace WellLog.Lib.Helpers
 
         public static sbyte ReadSSHORT(this Stream dlisStream)
         {
-            if (dlisStream == null) { return 0; }
-            return Convert.ToSByte(dlisStream.ReadByte());
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return 0; }
+            return dlisStream.ReadBytes(1).ConvertToSbyte();
         }
 
         public static short ReadSNORM(this Stream dlisStream)
         {
-            if (dlisStream == null) { return 0; }
-            return BitConverter.ToInt16(dlisStream.ReadBytes(2));
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return 0; }
+            return dlisStream.ReadBytes(2).ConvertToShort(false);
         }
 
         public static int ReadSLONG(this Stream dlisStream)
         {
-            if (dlisStream == null) { return 0; }
-            return BitConverter.ToInt32(dlisStream.ReadBytes(4));
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return 0; }
+            return dlisStream.ReadBytes(4).ConvertToInt(false);
         }
 
         public static byte ReadUSHORT(this Stream dlisStream)
         {
-            if (dlisStream == null) { return 0; }
-            return Convert.ToByte(dlisStream.ReadByte());
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return 0; }
+            return dlisStream.ReadBytes(1).ConvertToByte();
         }
 
         public static ushort ReadUNORM(this Stream dlisStream)
         {
-            if (dlisStream == null) { return 0; }
-            return BitConverter.ToUInt16(dlisStream.ReadBytes(2));
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return 0; }
+            return dlisStream.ReadBytes(2).ConvertToUshort(false);
         }
 
         public static uint ReadULONG(this Stream dlisStream)
         {
-            if (dlisStream == null) { return 0; }
-            return BitConverter.ToUInt32(dlisStream.ReadBytes(4));
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return 0; }
+            return dlisStream.ReadBytes(4).ConvertToUInt(false);
+        }
+
+        public static uint ReadUVARI1(this Stream dlisStream)
+        {
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return 0; }
+            return Convert.ToUInt32(dlisStream.ReadBytes(1).ConvertToByte());
+        }
+
+        public static uint ReadUVARI2(this Stream dlisStream)
+        {
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return 0; }
+
+            var buffer = dlisStream.ReadBytes(2);
+            if (buffer == null) { return 0; }
+
+            buffer[0] = buffer[0].AssignBitUsingMask(0b_1000_0000, false);
+            return Convert.ToUInt32(buffer.ConvertToUshort(false));
+        }
+
+        public static uint ReadUVARI4(this Stream dlisStream)
+        {
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return 0; }
+
+            var buffer = dlisStream.ReadBytes(4);
+            if (buffer == null) { return 0; }
+
+            buffer[0] = buffer[0].AssignBitUsingMask(0b_1100_0000, false);
+            return buffer.ConvertToUInt(false);
         }
 
         public static uint ReadUVARI(this Stream dlisStream)
         {
-            if (dlisStream == null) { return 0; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return 0; }
 
-            var b = Convert.ToByte(dlisStream.ReadByte());
-            if (b >> 7 == 0) { return Convert.ToUInt32(b); }
-            if (b >> 6 == 2) { return BitConverter.ToUInt32(new byte[2] { b.ClearBitUsingMask(0b_1000_0000), Convert.ToByte(dlisStream.ReadByte()) }); }
-            if (b >> 6 == 3)
-            {
-                var buffer = dlisStream.ReadBytes(3);
-                return BitConverter.ToUInt32(new byte[4] { b.ClearBitUsingMask(0b_1100_0000), buffer[0], buffer[1], buffer[2] });
-            }
+            var buffer = dlisStream.ReadBytes(1);
+            if (buffer == null) { return 0; }
 
-            return BitConverter.ToUInt32(dlisStream.ReadBytes(4));
+            dlisStream.Seek(-1, SeekOrigin.Current);
+            if (!buffer[0].GetBitUsingMask(0b_1000_0000)) { return dlisStream.ReadUVARI1(); }
+            if (!buffer[0].GetBitUsingMask(0b_0100_0000)) { return dlisStream.ReadUVARI2(); }
+            return dlisStream.ReadUVARI4();
         }
 
         public static string ReadIDENT(this Stream dlisStream)
         {
-            if (dlisStream == null) { return null; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return null; }
 
             var length = dlisStream.ReadByte();
             if (length < 0) { return null; }
+            if (length == 0) { return string.Empty; }
 
-            return Encoding.ASCII.GetString(dlisStream.ReadBytes(length));
+            var buffer = dlisStream.ReadBytes(length);
+            if (buffer == null) { return null; }
+
+            return Encoding.ASCII.GetString(buffer);
         }
 
         public static string ReadASCII(this Stream dlisStream)
         {
-            if (dlisStream == null) { return null; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return null; }
 
-            var length = Convert.ToInt32(dlisStream.ReadUVARI());
+            var length = dlisStream.ReadUVARI();
             if (length < 0) { return null; }
+            if (length == 0) { return string.Empty; }
 
-            return Encoding.ASCII.GetString(dlisStream.ReadBytes(length));
+            var buffer = dlisStream.ReadBytes(Convert.ToInt32(length));
+            if (buffer == null) { return null; }
+
+            return Encoding.ASCII.GetString(buffer);
+        }
+
+        public static DateTimeKind ToDateTimeKind(this byte b)
+        {
+            if (b == 1 || b == 2) { return DateTimeKind.Local; }
+            return DateTimeKind.Utc;
         }
 
         public static DateTime ReadDTIME(this Stream dlisStream)
         {
-            if (dlisStream == null) { return DateTime.MinValue; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return DateTime.MinValue; }
 
             var buffer = dlisStream.ReadBytes(8);
+            if (buffer == null) { return DateTime.MinValue; }
+
             var year = 1900 + buffer[0];
+            var tz = buffer[1].ClearBitUsingMask(0b_0000_1111).ShiftRight(4);
             var month = buffer[1].ClearBitUsingMask(0b_1111_0000);
             var day = buffer[2];
             var hour = buffer[3];
             var minute = buffer[4];
             var second = buffer[5];
-            var millisecond = BitConverter.ToUInt16(new byte[2] { buffer[6], buffer[7] });
+            var millisecond = buffer[6..8].ConvertToUshort(false);
 
-            return new DateTime(year, month, day, hour, minute, second, millisecond);
+            return new DateTime(year, month, day, hour, minute, second, millisecond, tz.ToDateTimeKind());
         }
 
         public static OBNAME ReadOBNAME(this Stream dlisStream)
         {
-            if (dlisStream == null) { return null; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return null; }
             return new OBNAME
             {
-                O = dlisStream.ReadUVARI(),
-                C = dlisStream.ReadUSHORT(),
-                I = dlisStream.ReadIDENT()
+                Origin = dlisStream.ReadUVARI(),
+                CopyNumber = dlisStream.ReadUSHORT(),
+                Identifier = dlisStream.ReadIDENT()
             };
         }
 
         public static OBJREF ReadOBJREF(this Stream dlisStream)
         {
-            if (dlisStream == null) { return null; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return null; }
             return new OBJREF
             {
-                T = dlisStream.ReadIDENT(),
-                N = dlisStream.ReadOBNAME()
+                ObjectType = dlisStream.ReadIDENT(),
+                Name = dlisStream.ReadOBNAME()
             };
         }
 
         public static ATTREF ReadATTREF(this Stream dlisStream)
         {
-            if (dlisStream == null) { return null; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return null; }
             return new ATTREF
             {
-                T = dlisStream.ReadIDENT(),
-                N = dlisStream.ReadOBNAME(),
-                L = dlisStream.ReadIDENT()
+                ObjectType = dlisStream.ReadIDENT(),
+                Name = dlisStream.ReadOBNAME(),
+                Label = dlisStream.ReadIDENT()
             };
         }
 
         public static bool ReadSTATUS(this Stream dlisStream)
         {
-            if (dlisStream == null) { return false; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return false; }
             return dlisStream.ReadUSHORT() != 0;
         }
 
         public static string ReadUNITS(this Stream dlisStream)
         {
-            if (dlisStream == null) { return null; }
+            if (dlisStream == null || dlisStream.IsAtEndOfStream()) { return null; }
 
-            var length = Convert.ToInt32(dlisStream.ReadUSHORT());
+            var length = dlisStream.ReadByte();
             if (length < 0) { return null; }
+            if (length == 0) { return string.Empty; }
 
-            return Encoding.ASCII.GetString(dlisStream.ReadBytes(length));
+            var buffer = dlisStream.ReadBytes(length);
+            if (buffer == null) { return null; }
+
+            return Encoding.ASCII.GetString(buffer);
         }
     }
 }

--- a/WellLog.Lib/Helpers/StreamHelpers.cs
+++ b/WellLog.Lib/Helpers/StreamHelpers.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace WellLog.Lib.Helpers
+{
+    public static class StreamHelpers
+    {
+        public static byte[] ReadBytes(this Stream s, int numBytes)
+        {
+            if (s == null) { return null; }
+            if (numBytes < 0) { return null; }
+            if (numBytes == 0) { return new byte[0]; }
+
+            var buffer = new byte[numBytes];
+            var bytesRead = s.Read(buffer, 0, numBytes);
+
+            if (bytesRead < numBytes) { return null; }
+            return buffer;
+        }
+
+        public static bool IsAtEndOfStream(this Stream s)
+        {
+            if (s == null) { return false; }
+            return s.Position >= s.Length;
+        }
+    }
+}

--- a/WellLog.Lib/Models/DLIS/ATTREF.cs
+++ b/WellLog.Lib/Models/DLIS/ATTREF.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WellLog.Lib.Models.DLIS
+{
+    public class ATTREF
+    {
+        public string T { get; set; }
+        public OBNAME N { get; set; }
+        public string L { get; set; }
+    }
+}

--- a/WellLog.Lib/Models/DLIS/ATTREF.cs
+++ b/WellLog.Lib/Models/DLIS/ATTREF.cs
@@ -6,8 +6,8 @@ namespace WellLog.Lib.Models.DLIS
 {
     public class ATTREF
     {
-        public string T { get; set; }
-        public OBNAME N { get; set; }
-        public string L { get; set; }
+        public string ObjectType { get; set; }
+        public OBNAME Name { get; set; }
+        public string Label { get; set; }
     }
 }

--- a/WellLog.Lib/Models/DLIS/CDOUBL.cs
+++ b/WellLog.Lib/Models/DLIS/CDOUBL.cs
@@ -1,0 +1,8 @@
+﻿namespace WellLog.Lib.Models.DLIS
+{
+    public class CDOUBL
+    {
+        public double R { get; set; }
+        public double I { get; set; }
+    }
+}

--- a/WellLog.Lib/Models/DLIS/CSINGL.cs
+++ b/WellLog.Lib/Models/DLIS/CSINGL.cs
@@ -1,0 +1,8 @@
+﻿namespace WellLog.Lib.Models.DLIS
+{
+    public class CSINGL
+    {
+        public float R { get; set; }
+        public float I { get; set; }
+    }
+}

--- a/WellLog.Lib/Models/DLIS/ComponentDescriptor.cs
+++ b/WellLog.Lib/Models/DLIS/ComponentDescriptor.cs
@@ -25,13 +25,13 @@ namespace WellLog.Lib.Models.DLIS
 
         private readonly byte _descriptor;
 
-        public bool IsAbsentAttribute => _descriptor.IsComponentRole(ABSENT_ATTRIBUTE_ROLE);
-        public bool IsAttribute => _descriptor.IsComponentRole(ATTRIBUTE_ROLE);
-        public bool IsInvariantAttribute => _descriptor.IsComponentRole(INVARIANT_ATTRIBUTE_ROLE);
-        public bool IsObject => _descriptor.IsComponentRole(OBJECT_ROLE);
-        public bool IsRedundantSet => _descriptor.IsComponentRole(REDUNDANT_SET_ROLE);
-        public bool IsReplacementSet => _descriptor.IsComponentRole(REPLACEMENT_SET_ROLE);
-        public bool IsSet => _descriptor.IsComponentRole(SET_ROLE);
+        public bool IsAbsentAttribute => _descriptor.HasDlisComponentRole(ABSENT_ATTRIBUTE_ROLE);
+        public bool IsAttribute => _descriptor.HasDlisComponentRole(ATTRIBUTE_ROLE);
+        public bool IsInvariantAttribute => _descriptor.HasDlisComponentRole(INVARIANT_ATTRIBUTE_ROLE);
+        public bool IsObject => _descriptor.HasDlisComponentRole(OBJECT_ROLE);
+        public bool IsRedundantSet => _descriptor.HasDlisComponentRole(REDUNDANT_SET_ROLE);
+        public bool IsReplacementSet => _descriptor.HasDlisComponentRole(REPLACEMENT_SET_ROLE);
+        public bool IsSet => _descriptor.HasDlisComponentRole(SET_ROLE);
 
         public bool DoesSetHaveType => (IsSet || IsRedundantSet || IsReplacementSet) ? _descriptor.GetBitUsingMask(SET_TYPE_MASK) : false;
         public bool DoesSetHaveName => (IsSet || IsRedundantSet || IsReplacementSet) ? _descriptor.GetBitUsingMask(SET_NAME_MASK) : false;

--- a/WellLog.Lib/Models/DLIS/FDOUB1.cs
+++ b/WellLog.Lib/Models/DLIS/FDOUB1.cs
@@ -1,0 +1,8 @@
+﻿namespace WellLog.Lib.Models.DLIS
+{
+    public class FDOUB1
+    {
+        public double V { get; set; }
+        public double A { get; set; }
+    }
+}

--- a/WellLog.Lib/Models/DLIS/FDOUB2.cs
+++ b/WellLog.Lib/Models/DLIS/FDOUB2.cs
@@ -1,0 +1,9 @@
+﻿namespace WellLog.Lib.Models.DLIS
+{
+    public class FDOUB2
+    {
+        public double V { get; set; }
+        public double A { get; set; }
+        public double B { get; set; }
+    }
+}

--- a/WellLog.Lib/Models/DLIS/FSING1.cs
+++ b/WellLog.Lib/Models/DLIS/FSING1.cs
@@ -1,0 +1,8 @@
+﻿namespace WellLog.Lib.Models.DLIS
+{
+    public class FSING1
+    {
+        public float V { get; set; }
+        public float A { get; set; }
+    }
+}

--- a/WellLog.Lib/Models/DLIS/FSING2.cs
+++ b/WellLog.Lib/Models/DLIS/FSING2.cs
@@ -1,0 +1,9 @@
+﻿namespace WellLog.Lib.Models.DLIS
+{
+    public class FSING2
+    {
+        public float V { get; set; }
+        public float A { get; set; }
+        public float B { get; set; }
+    }
+}

--- a/WellLog.Lib/Models/DLIS/OBJREF.cs
+++ b/WellLog.Lib/Models/DLIS/OBJREF.cs
@@ -1,0 +1,8 @@
+﻿namespace WellLog.Lib.Models.DLIS
+{
+    public class OBJREF
+    {
+        public string T { get; set; }
+        public OBNAME N { get; set; }
+    }
+}

--- a/WellLog.Lib/Models/DLIS/OBJREF.cs
+++ b/WellLog.Lib/Models/DLIS/OBJREF.cs
@@ -2,7 +2,7 @@
 {
     public class OBJREF
     {
-        public string T { get; set; }
-        public OBNAME N { get; set; }
+        public string ObjectType { get; set; }
+        public OBNAME Name { get; set; }
     }
 }

--- a/WellLog.Lib/Models/DLIS/OBNAME.cs
+++ b/WellLog.Lib/Models/DLIS/OBNAME.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WellLog.Lib.Models.DLIS
+{
+    public class OBNAME
+    {
+        public uint O { get; set; }
+        public byte C { get; set; }
+        public string I { get; set; }
+    }
+}

--- a/WellLog.Lib/Models/DLIS/OBNAME.cs
+++ b/WellLog.Lib/Models/DLIS/OBNAME.cs
@@ -6,8 +6,8 @@ namespace WellLog.Lib.Models.DLIS
 {
     public class OBNAME
     {
-        public uint O { get; set; }
-        public byte C { get; set; }
-        public string I { get; set; }
+        public uint Origin { get; set; }
+        public byte CopyNumber { get; set; }
+        public string Identifier { get; set; }
     }
 }


### PR DESCRIPTION
added helpers to read [DLIS representation codes](http://w3.energistics.org/rp66/v1/Toc/main.html) from a stream.  many of the representation codes are straight forward, but the floating point representation codes get a bit hairy.  the vax interpretation code algorithm was pulled from some source code i downloaded from [libvaxdata: VAX Data Format Conversion Routines](https://pubs.usgs.gov/of/2005/1424/).